### PR TITLE
Stop the update test running a real deploy

### DIFF
--- a/app/Http/Controllers/SettingController.php
+++ b/app/Http/Controllers/SettingController.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers;
 use App\Http\Requests\SettingsRequest;
 use App\Http\Resources\PublicSettingResource;
 use App\Models\Setting;
+use App\Services\ApplicationUpdater;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Symfony\Component\Process\Process;
 
 class SettingController extends Controller
 {
@@ -39,27 +39,12 @@ class SettingController extends Controller
         return response()->json(['saved' => 1]);
     }
 
-    public function updateApplication()
+    public function updateApplication(ApplicationUpdater $updater)
     {
-        // Run it with bash, not sh: the script uses [[ ]] and (( )), which
-        // dash - /bin/sh on Debian - cannot parse.
-        $process = new Process(['bash', base_path().'/update.sh'], base_path());
-        $process->setTimeout(3600);
+        $result = $updater->run();
 
-        // The web server's PATH does not necessarily include the PHP binary
-        // that is serving this request, so hand it over explicitly rather than
-        // letting the script guess.
-        $process->setEnv([
-            'DMP_PHP' => PHP_BINARY,
-            'PATH' => dirname(PHP_BINARY).PATH_SEPARATOR.(getenv('PATH') ?: '/usr/local/bin:/usr/bin:/bin'),
-        ]);
-
-        $process->run();
-
-        $output = trim($process->getOutput()."\n".$process->getErrorOutput());
-
-        if (! $process->isSuccessful()) {
-            Log::warning('Update script failed: '.$output);
+        if (! $result['success']) {
+            Log::warning('Update script failed: '.$result['output']);
 
             // This used to return 200 with success:false, so the About page
             // took the .then() branch and told the operator the update had
@@ -67,13 +52,13 @@ class SettingController extends Controller
             return response()->json([
                 'success' => false,
                 'message' => 'The update did not run.',
-                'output' => $output,
+                'output' => $result['output'],
             ], 500);
         }
 
-        Log::info($output);
+        Log::info($result['output']);
 
-        return response()->json(['success' => true, 'output' => $output]);
+        return response()->json(['success' => true, 'output' => $result['output']]);
     }
 
     public function checkUpdate()

--- a/app/Services/ApplicationUpdater.php
+++ b/app/Services/ApplicationUpdater.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Runs the deploy script.
+ *
+ * Behind a service so it can be swapped out in tests. Calling the endpoint
+ * directly from a test executes a real deploy - 'artisan down', 'git pull',
+ * 'composer install --no-dev' - which will happily delete the dev
+ * dependencies out from under the test runner.
+ */
+class ApplicationUpdater
+{
+    /**
+     * @return array{success: bool, output: string}
+     */
+    public function run(): array
+    {
+        // bash, not sh: update.sh uses [[ ]] and (( )), and /bin/sh is dash
+        // on Debian. The PHP binary is passed explicitly because the web
+        // server's PATH does not necessarily contain one.
+        $process = new Process(['bash', base_path().'/update.sh'], base_path());
+        $process->setTimeout(3600);
+        $process->setEnv([
+            'DMP_PHP' => PHP_BINARY,
+            'PATH' => dirname(PHP_BINARY).PATH_SEPARATOR.(getenv('PATH') ?: '/usr/local/bin:/usr/bin:/bin'),
+        ]);
+
+        $process->run();
+
+        return [
+            'success' => $process->isSuccessful(),
+            'output' => trim($process->getOutput()."\n".$process->getErrorOutput()),
+        ];
+    }
+}

--- a/tests/Feature/UpdateApplicationTest.php
+++ b/tests/Feature/UpdateApplicationTest.php
@@ -2,39 +2,68 @@
 
 namespace Tests\Feature;
 
+use App\Services\ApplicationUpdater;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
+/**
+ * The update endpoint.
+ *
+ * ApplicationUpdater is always faked here. Letting the real one run would
+ * execute a deploy against the checkout the tests are running from - it takes
+ * the app down, pulls, and runs 'composer install --no-dev', which removes
+ * PHPUnit while PHPUnit is using it.
+ */
 class UpdateApplicationTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * The About page decides between its success and failure branches on the
-     * HTTP status. This endpoint used to answer 200 with success:false when
-     * the script had refused to run, so the operator was told the update had
-     * completed while nothing had happened.
-     */
-    public function test_a_failed_update_reports_a_failure_status_and_the_script_output(): void
+    private function fakeUpdater(bool $success, string $output): void
     {
-        // update.sh stops before touching anything when PHP is too old, which
-        // is what an install predating this release will hit.
-        $response = $this->actingAsAdmin()->getJson('/api/update-application');
+        $this->instance(ApplicationUpdater::class, new class($success, $output) extends ApplicationUpdater
+        {
+            public function __construct(private bool $success, private string $output) {}
 
-        if ($response->getStatusCode() === 200) {
-            $this->assertTrue($response->json('success'), 'A 200 must mean the update actually ran.');
+            public function run(): array
+            {
+                return ['success' => $this->success, 'output' => $this->output];
+            }
+        });
+    }
 
-            return;
-        }
+    /**
+     * The About page picks its success or failure branch from the status code,
+     * so a refused update has to be a failure status. It used to answer 200
+     * with success:false, and the page reported "Update complete".
+     */
+    public function test_a_refused_update_answers_500_with_the_script_output(): void
+    {
+        $this->fakeUpdater(false, "Deploy started\nThis release needs PHP 8.3 or newer");
 
-        $response->assertStatus(500)
+        $this->actingAsAdmin()
+            ->getJson('/api/update-application')
+            ->assertStatus(500)
             ->assertJsonPath('success', false)
-            ->assertJsonStructure(['success', 'message', 'output']);
+            ->assertJsonPath('message', 'The update did not run.')
+            ->assertJsonFragment(['output' => "Deploy started\nThis release needs PHP 8.3 or newer"]);
+    }
+
+    public function test_a_successful_update_answers_200(): void
+    {
+        $this->fakeUpdater(true, 'Deploy finished');
+
+        $this->actingAsAdmin()
+            ->getJson('/api/update-application')
+            ->assertOk()
+            ->assertJsonPath('success', true)
+            ->assertJsonPath('output', 'Deploy finished');
     }
 
     public function test_the_update_endpoint_requires_authentication(): void
     {
+        // No fake bound: an unauthenticated request must be turned away before
+        // anything is executed.
         $this->getJson('/api/update-application')->assertUnauthorized();
     }
 
@@ -46,9 +75,6 @@ class UpdateApplicationTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $version['latest']);
         $this->assertNotEmpty($version['changelog']);
         $this->assertNotEmpty($version['past_updates']);
-
-        // The previous release has to stay in the history so devices can see
-        // what changed.
         $this->assertSame('1.7.153', $version['past_updates'][0]['version']);
     }
 


### PR DESCRIPTION
`main` is red. `UpdateApplicationTest` called `/api/update-application` for
real, so the controller executed `update.sh` against the checkout the suite
was running from:

```
artisan down  ->  git pull  ->  composer install --no-dev
```

That last step removes the dev dependencies — including PHPUnit and Collision —
**while PHPUnit is running**, which is why the CI failures were a cascade of
`No such file or directory` for vendor files that existed moments earlier.

It passed on the release branch only because the `git pull` failed there and
the script exited before reaching composer.

## Fix

Move the work behind `ApplicationUpdater` so it can be swapped in tests, and
fake it in every case that reaches the controller. The unauthenticated test
deliberately binds no fake: the request has to be refused before anything would
execute.

This also removes the same hazard for anyone running the suite locally, where a
real deploy against a working copy would be a good deal worse than on a
throwaway runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)