### PR TITLE
Correct the project attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,11 @@ opened a websocket to Plex from the browser, which required putting
 }
 ```
 
+## Credits
+
+Originally created by Don Jones. Maintained by
+[Mike Francis](https://github.com/devMikeFrancis).
+
 ## License
 
 DMP open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,16 @@
         "raspberry-pi"
     ],
     "license": "MIT",
+    "authors": [
+        {
+            "name": "Don Jones",
+            "role": "Creator"
+        },
+        {
+            "name": "Mike Francis",
+            "role": "Maintainer"
+        }
+    ],
     "require": {
         "guzzlehttp/guzzle": "^7.9",
         "intervention/image": "^4.2",

--- a/resources/js/Views/About.vue
+++ b/resources/js/Views/About.vue
@@ -53,13 +53,16 @@
                                 </div>
 
                                 <p class="text-white">
-                                    This project is maintained by Don Jones at
+                                    This project is maintained by Mike Francis at
                                     <a
                                         class="text-gray-400 hover:text-white"
                                         href="https://github.com/devMikeFrancis/digital-movie-poster"
                                         target="_blank"
                                         >https://github.com/devMikeFrancis/digital-movie-poster</a
                                     >
+                                </p>
+                                <p class="text-gray-400 text-sm mt-2">
+                                    Originally created by Don Jones.
                                 </p>
 
                                 <div class="pt-12">


### PR DESCRIPTION
The About page read:

> This project is maintained by Don Jones at github.com/**devMikeFrancis**/…

An earlier commit in the refresh corrected the repository URL but left the
name, so the line credited one person and linked another's repository.

Don Jones wrote 182 of the 207 commits and is credited as the creator; Mike
Francis owns and maintains the repository the page links to. Both are now
named — on the About page, in the README, and in `composer.json`, which
declared no `authors` at all.

There is still no `LICENSE` file, only the MIT reference in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)