### PR TITLE
Add the MIT license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2021-2022 Don Jones
+Copyright (c) 2024-2026 Mike Francis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -319,4 +319,4 @@ Originally created by Don Jones. Maintained by
 
 ## License
 
-DMP open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+DMP is open-sourced software licensed under the [MIT license](LICENSE).


### PR DESCRIPTION
The project has always declared MIT — in `composer.json` and at the bottom of
the README — but carried no `LICENSE` file and no copyright notice anywhere.
So the licence was not machine-detectable by GitHub or packagist, and the terms
were not actually distributed with the software.

Copyright years follow the commit history rather than being guessed:

| | Commits | Years |
|---|---|---|
| Don Jones | 182 | 2021–2022 |
| Mike Francis | 26 | 2024–2026 |

The README's licence line now links the file instead of opensource.org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)