### PR TITLE
Name the npm package so the lockfile stops churning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-    "name": "dmp",
+    "name": "digital-movie-poster",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
+            "name": "digital-movie-poster",
             "dependencies": {
                 "axios": "^1.19.0",
                 "click-outside-vue3": "^4.0.1",
@@ -984,6 +985,72 @@
             "engines": {
                 "node": ">=14.0.0"
             }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+            "version": "1.11.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.2",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+            "version": "1.11.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.4",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+            "version": "0.10.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+            "version": "2.8.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "0BSD",
+            "optional": true
         },
         "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
             "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "digital-movie-poster",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
`package.json` declared no `name`, so npm derives one from the containing
directory and writes it into `package-lock.json`. Cloning into a differently
named directory produces a spurious lockfile diff on the next `npm install` —
which is exactly what happened here.

Pins it to `digital-movie-poster`. Also picks up the bundled optional
`@tailwindcss/oxide-wasm32-wasi` entries a full resolve adds; verified `npm ci`
accepts the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)