### PR TITLE
Find titles by name, and fetch artwork before saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,25 @@ After you've added posters and are back on the DMP screen you can always return 
 
 ### IMDB/TMDB Poster Data Auto-population
 
-When using the IMDB ID to manage poster data the application will use [TMDB API](https://developers.themoviedb.org/3/getting-started/introduction) to populate the metadata and poster image.
+Poster metadata and artwork come from the
+[TMDB API](https://developer.themoviedb.org/docs). Enter your TMDB API key in
+Settings first - everything below needs it.
 
-Enter your TMDB api key in the DMP settings.
+DMP identifies titles by their IMDB ID. IMDB itself has no public API, so TMDB
+is what answers; it accepts IMDB IDs as well as its own, and hands the IMDB ID
+back when you search.
+
+**Find a title** - if you do not know the IMDB ID, search by name in the poster
+editor. Results show the artwork, year and whether it is a movie or a TV show,
+so remakes and same-named titles are easy to tell apart. Pick one and confirm,
+and the IMDB ID, title, rating, audience score, runtime and trailer are filled
+in for you.
+
+**Fetch media** - if you already have the IMDB ID, this pulls the same data in
+straight away and shows the artwork, so you can check it before saving. Without
+it the artwork is still downloaded, but not until you save.
+
+The artwork is downloaded, resized and converted to WebP on save.
 
 ## Display on/off schedule
 

--- a/app/Http/Controllers/TmdbController.php
+++ b/app/Http/Controllers/TmdbController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Services\TmdbService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Title lookup for the poster editor.
+ *
+ * Privileged: these spend the operator's TMDB API key, and are only ever
+ * called from the admin UI.
+ */
+class TmdbController extends Controller
+{
+    /**
+     * Titles matching a name, so a poster can be created without knowing the
+     * IMDB id up front.
+     */
+    public function search(Request $request, TmdbService $tmdb): JsonResponse
+    {
+        $data = $request->validate([
+            'query' => ['required', 'string', 'min:2', 'max:120'],
+            'media_type' => ['nullable', 'in:movie,tv,show'],
+        ]);
+
+        return $this->attempt(fn () => [
+            'results' => $tmdb->search($data['query'], $data['media_type'] ?? 'movie'),
+        ]);
+    }
+
+    /**
+     * Everything needed to fill in the form, by either id.
+     *
+     * The editor calls this when a search result is picked, and when "Fetch
+     * media" is used with an IMDB id typed in directly.
+     */
+    public function title(Request $request, TmdbService $tmdb): JsonResponse
+    {
+        $data = $request->validate([
+            'imdb_id' => ['required_without:tmdb_id', 'nullable', 'string', 'max:20'],
+            'tmdb_id' => ['required_without:imdb_id', 'nullable', 'integer'],
+            'media_type' => ['nullable', 'in:movie,tv,show'],
+        ]);
+
+        $mediaType = $data['media_type'] ?? 'movie';
+
+        return $this->attempt(fn () => ['title' => empty($data['tmdb_id'])
+            ? $tmdb->detailsByImdbId($data['imdb_id'], $mediaType)
+            : $tmdb->detailsByTmdbId($data['tmdb_id'], $mediaType)]);
+    }
+
+    /**
+     * A missing key, a rejected key or an unreachable TMDB are all things the
+     * operator can act on, so they come back as a readable message rather than
+     * a stack trace.
+     *
+     * @param  callable(): array<string, mixed>  $work
+     */
+    private function attempt(callable $work): JsonResponse
+    {
+        try {
+            return response()->json($work());
+        } catch (RuntimeException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        } catch (Throwable $e) {
+            Log::warning('TMDB request failed: '.$e->getMessage());
+
+            return response()->json(['message' => 'Could not reach TMDB. Try again in a moment.'], 502);
+        }
+    }
+}

--- a/app/Services/TmdbService.php
+++ b/app/Services/TmdbService.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Setting;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * Client for The Movie Database.
+ *
+ * DMP identifies titles by their IMDB id, but IMDB has no public API - TMDB is
+ * what actually answers, and it accepts IMDB ids as well as its own. Searching
+ * therefore means searching TMDB and handing back the IMDB id of whatever the
+ * operator picks.
+ */
+class TmdbService
+{
+    public function __construct(private ?Setting $settings = null)
+    {
+        $this->settings = $settings ?: Setting::first();
+    }
+
+    public function configured(): bool
+    {
+        return ! empty($this->settings?->tmdb_api_key_v3);
+    }
+
+    /**
+     * Titles matching a name, newest and most popular first.
+     *
+     * Deliberately does not resolve each result's IMDB id: that is one extra
+     * request per row, and only the title the operator actually picks needs it.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function search(string $query, string $mediaType = 'movie'): array
+    {
+        $mediaType = $this->normaliseType($mediaType);
+
+        $response = $this->get('/search/'.$mediaType, [
+            'query' => $query,
+            'include_adult' => 'false',
+        ]);
+
+        $results = $response['results'] ?? [];
+
+        return array_values(array_map(
+            fn (array $item) => $this->summarise($item, $mediaType),
+            array_slice($results, 0, 20)
+        ));
+    }
+
+    /**
+     * Everything needed to fill in the poster form, by TMDB id.
+     *
+     * @return array<string, mixed>
+     */
+    public function detailsByTmdbId(int|string $tmdbId, string $mediaType = 'movie'): array
+    {
+        $mediaType = $this->normaliseType($mediaType);
+
+        $append = $mediaType === 'movie'
+            ? 'videos,images,release_dates,external_ids'
+            : 'content_ratings,external_ids';
+
+        $item = $this->get('/'.$mediaType.'/'.$tmdbId, ['append_to_response' => $append]);
+
+        if (! isset($item['id'])) {
+            throw new RuntimeException('That title could not be found on TMDB.');
+        }
+
+        return $this->present($item, $mediaType);
+    }
+
+    /**
+     * The same, by IMDB id - what the poster form has always been keyed on.
+     *
+     * @return array<string, mixed>
+     */
+    public function detailsByImdbId(string $imdbId, string $mediaType = 'movie'): array
+    {
+        $mediaType = $this->normaliseType($mediaType);
+
+        // /find is the documented way to resolve an external id, and works for
+        // both movies and shows.
+        $found = $this->get('/find/'.$imdbId, ['external_source' => 'imdb_id']);
+        $key = $mediaType === 'movie' ? 'movie_results' : 'tv_results';
+        $match = $found[$key][0] ?? null;
+
+        if (! $match) {
+            throw new RuntimeException(
+                'No '.($mediaType === 'movie' ? 'movie' : 'TV show').' on TMDB has the IMDB id '.$imdbId.'.'
+            );
+        }
+
+        return $this->detailsByTmdbId($match['id'], $mediaType);
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function summarise(array $item, string $mediaType): array
+    {
+        $title = $item['title'] ?? $item['name'] ?? 'Untitled';
+        $date = $item['release_date'] ?? $item['first_air_date'] ?? '';
+
+        return [
+            'tmdb_id' => $item['id'] ?? null,
+            'title' => $title,
+            'year' => $date ? substr($date, 0, 4) : null,
+            'media_type' => $mediaType,
+            'overview' => $item['overview'] ?? '',
+            'audience_rating' => $item['vote_average'] ?? null,
+            'thumbnail' => $this->image($item['poster_path'] ?? null, 'w154'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function present(array $item, string $mediaType): array
+    {
+        $isMovie = $mediaType === 'movie';
+
+        return [
+            'tmdb_id' => $item['id'],
+            'imdb_id' => $item['external_ids']['imdb_id'] ?? ($item['imdb_id'] ?? null),
+            'media_type' => $mediaType,
+            'title' => $item['title'] ?? $item['name'] ?? 'Untitled',
+            'year' => substr((string) ($item['release_date'] ?? $item['first_air_date'] ?? ''), 0, 4) ?: null,
+            'overview' => $item['overview'] ?? '',
+            'audience_rating' => $item['vote_average'] ?? null,
+            'runtime' => $isMovie
+                ? ($item['runtime'] ?? null)
+                : ($item['episode_run_time'][0] ?? null),
+            'mpaa_rating' => $isMovie
+                ? $this->certification($item['release_dates']['results'] ?? [])
+                : $this->contentRating($item['content_ratings']['results'] ?? []),
+            'trailer_id' => $isMovie ? $this->trailer($item['videos']['results'] ?? []) : null,
+            'poster_url' => $this->image($item['poster_path'] ?? null, 'original'),
+            'preview_url' => $this->image($item['poster_path'] ?? null, 'w342'),
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $releaseDates
+     */
+    private function certification(array $releaseDates): ?string
+    {
+        foreach ($releaseDates as $entry) {
+            if (($entry['iso_3166_1'] ?? null) !== 'US') {
+                continue;
+            }
+
+            foreach ($entry['release_dates'] ?? [] as $release) {
+                if (! empty($release['certification'])) {
+                    return $release['certification'];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $contentRatings
+     */
+    private function contentRating(array $contentRatings): ?string
+    {
+        foreach ($contentRatings as $entry) {
+            if (($entry['iso_3166_1'] ?? null) === 'US' && ! empty($entry['rating'])) {
+                return $entry['rating'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $videos
+     */
+    private function trailer(array $videos): ?string
+    {
+        foreach ($videos as $video) {
+            if (($video['type'] ?? null) === 'Trailer'
+                && ($video['site'] ?? null) === 'YouTube'
+                && ($video['official'] ?? false) === true) {
+                return $video['key'] ?? null;
+            }
+        }
+
+        // Fall back to any YouTube trailer rather than returning nothing.
+        foreach ($videos as $video) {
+            if (($video['type'] ?? null) === 'Trailer' && ($video['site'] ?? null) === 'YouTube') {
+                return $video['key'] ?? null;
+            }
+        }
+
+        return null;
+    }
+
+    private function image(?string $path, string $size): ?string
+    {
+        return $path
+            ? rtrim((string) config('dmp.tmdb.image_base_url'), '/').'/'.$size.$path
+            : null;
+    }
+
+    private function normaliseType(string $mediaType): string
+    {
+        return in_array(strtolower($mediaType), ['tv', 'show'], true) ? 'tv' : 'movie';
+    }
+
+    /**
+     * @param  array<string, mixed>  $query
+     * @return array<string, mixed>
+     */
+    private function get(string $path, array $query = []): array
+    {
+        if (! $this->configured()) {
+            throw new RuntimeException('No TMDB API key is set. Add one in Settings.');
+        }
+
+        $response = Http::timeout(15)
+            ->acceptJson()
+            ->get(rtrim((string) config('dmp.tmdb.base_url'), '/').$path, $query + ['api_key' => $this->settings->tmdb_api_key_v3]);
+
+        if ($response->status() === 401) {
+            throw new RuntimeException('TMDB rejected the API key. Check it in Settings.');
+        }
+
+        if ($response->status() === 404) {
+            throw new RuntimeException('TMDB has no record of that title.');
+        }
+
+        if (! $response->successful()) {
+            throw new RuntimeException('TMDB is not responding (HTTP '.$response->status().').');
+        }
+
+        return $response->json() ?? [];
+    }
+}

--- a/app/Traits/PosterProcess.php
+++ b/app/Traits/PosterProcess.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use App\Models\Poster;
+use App\Services\TmdbService;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
@@ -136,144 +137,35 @@ trait PosterProcess
     }
 
     /**
-     * Get movie or tv meta data
+     * Get movie or tv meta data from TMDB.
      *
-     * @param  string  $mediaId  imdbid|tv name
+     * The HTTP client, response shaping and rating extraction now live in
+     * TmdbService, so the poster editor's search and "fetch media" actions and
+     * this save-time lookup all agree about what a title looks like.
+     *
+     * @param  string  $mediaId  IMDB id
      * @param  string  $type  movie|tv
+     * @return array<string, mixed>
      */
     public function posterMeta($mediaId, $type = 'movie'): array
     {
-        if ($type === 'movie') {
-            $res = $this->movieEndpoint($mediaId);
+        try {
+            $details = app(TmdbService::class)->detailsByImdbId($mediaId, $type);
+        } catch (\Throwable $e) {
+            Log::info('TMDB lookup failed for "'.$mediaId.'": '.$e->getMessage());
 
-            return $this->getMovieData($res);
+            return ['success' => false, 'message' => $e->getMessage()];
         }
-
-        if ($type === 'tv') {
-            $res = $this->tvEndpoint($mediaId);
-
-            return $this->getTvData($res);
-        }
-    }
-
-    private function movieEndpoint($imdbId)
-    {
-        $response = Http::withHeaders([
-            'Accept' => 'application/json',
-        ])->get('https://api.themoviedb.org/3/movie/'.$imdbId.'?api_key='.$this->settings->tmdb_api_key_v3.'&append_to_response=videos,images,release_dates');
-
-        return $response->json();
-    }
-
-    private function tvEndpoint($imdbId)
-    {
-        $response = Http::withHeaders([
-            'Accept' => 'application/json',
-        ])->get('https://api.themoviedb.org/3/find/'.$imdbId.'?api_key='.$this->settings->tmdb_api_key_v3.'&external_source=imdb_id');
-
-        $items = $response->json();
-
-        return $items['tv_results'];
-    }
-
-    private function getMovieData($res): array
-    {
-        $success = true;
-        $message = '';
-
-        if (isset($res['success']) && ! $res['success']) {
-            $arr['success'] = false;
-            $arr['message'] = 'Movie not found';
-
-            return $arr;
-        }
-
-        $imageLocation = 'https://image.tmdb.org/t/p/original'.$res['poster_path'];
-        $audienceRating = $res['vote_average'];
-        $movieRating = $this->getMovieRating($res['release_dates']['results']);
-        $trailerId = $this->getMovieTrailerId($res['videos']['results']);
 
         return [
-            'success' => $success,
-            'message' => $message,
-            'title' => $res['title'],
-            'image' => $imageLocation,
-            'mpaa_rating' => $movieRating,
-            'audience_rating' => $audienceRating,
-            'trailer_id' => $trailerId,
-            'runtime' => $res['runtime'],
+            'success' => true,
+            'message' => '',
+            'title' => $details['title'],
+            'image' => $details['poster_url'],
+            'mpaa_rating' => $details['mpaa_rating'],
+            'audience_rating' => $details['audience_rating'],
+            'trailer_id' => $details['trailer_id'],
+            'runtime' => $details['runtime'],
         ];
-    }
-
-    private function getTvData($res)
-    {
-        $success = true;
-        $message = '';
-        $arr = [];
-
-        if (count($res) === 0) {
-            $arr['success'] = false;
-            $arr['message'] = 'Tv show not found';
-
-            return $arr;
-        }
-
-        $topResult = $res[0];
-
-        $tvMeta = $this->getTvMeta($topResult['id']);
-
-        $imageLocation = 'https://image.tmdb.org/t/p/original'.$topResult['poster_path'];
-        $audienceRating = $topResult['vote_average'];
-        $tvRating = $this->getTvRating($tvMeta['content_ratings']['results']);
-
-        return [
-            'success' => $success,
-            'message' => $message,
-            'title' => $topResult['name'],
-            'image' => $imageLocation,
-            'mpaa_rating' => $tvRating,
-            'trailer_id' => '',
-            'audience_rating' => $audienceRating,
-            'runtime' => isset($tvMeta['episode_run_time'][0]) ? $tvMeta['episode_run_time'][0] : null,
-        ];
-    }
-
-    private function getTvMeta($tvId)
-    {
-        $response = Http::withHeaders([
-            'Accept' => 'application/json',
-        ])->get('https://api.themoviedb.org/3/tv/'.$tvId.'?api_key='.$this->settings->tmdb_api_key_v3.'&append_to_response=content_ratings');
-
-        return $response->json();
-    }
-
-    private function getMovieRating($releaseDates)
-    {
-        foreach ($releaseDates as $releaseDate) {
-            if ($releaseDate['iso_3166_1'] === 'US') {
-                return $releaseDate['release_dates'][0]['certification'];
-            }
-        }
-    }
-
-    private function getTvRating($contentRatings)
-    {
-        foreach ($contentRatings as $contentRating) {
-            if ($contentRating['iso_3166_1'] === 'US') {
-                return $contentRating['rating'];
-            }
-        }
-    }
-
-    private function getMovieTrailerId($videos)
-    {
-        foreach ($videos as $video) {
-            if (
-                $video['type'] === 'Trailer' &&
-                $video['official'] === true &&
-                $video['site'] === 'YouTube') {
-                return $video['key'];
-            }
-        }
     }
 }

--- a/config/dmp.php
+++ b/config/dmp.php
@@ -33,6 +33,21 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | TMDB
+    |--------------------------------------------------------------------------
+    |
+    | Where title lookups go. Overridable so the integration can be pointed at
+    | a stub or a caching proxy; the API key itself lives in Settings.
+    |
+    */
+
+    'tmdb' => [
+        'base_url' => env('TMDB_BASE_URL', 'https://api.themoviedb.org/3'),
+        'image_base_url' => env('TMDB_IMAGE_BASE_URL', 'https://image.tmdb.org/t/p'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Motion Sensor
     |--------------------------------------------------------------------------
     |

--- a/resources/js/Views/PostersEdit.vue
+++ b/resources/js/Views/PostersEdit.vue
@@ -18,6 +18,13 @@
                                 />
                             </div>
                             <div class="lg:col-span-8">
+                                <title-lookup
+                                    :media-type="poster.media_type"
+                                    @selected="applyTitle"
+                                ></title-lookup>
+
+                                <hr class="border-grey-500 mb-5" />
+
                                 <div class="mb-5">
                                     <label
                                         for="movie-title"
@@ -25,16 +32,47 @@
                                         >IMDB ID</label
                                     >
 
-                                    <input
-                                        type="text"
-                                        class="text-black w-full"
-                                        id="movie-title"
-                                        v-model="poster.imdb_id"
-                                        required
-                                    />
+                                    <div class="flex gap-2">
+                                        <input
+                                            type="text"
+                                            class="text-black w-full"
+                                            id="movie-title"
+                                            v-model="poster.imdb_id"
+                                            required
+                                        />
+                                        <button
+                                            type="button"
+                                            class="btn text-black bg-gray-300 px-4 rounded-sm hover:bg-gray-100 whitespace-nowrap"
+                                            :disabled="fetching"
+                                            @click.prevent="fetchMedia"
+                                        >
+                                            {{ fetching ? 'Fetching…' : 'Fetch media' }}
+                                        </button>
+                                    </div>
                                     <div id="movie-posterHelp" class="text-gray-400 text-sm">
                                         If used, TMDB API will override movie data for this poster
-                                        except theme music and settings.
+                                        except theme music and settings. "Fetch media" pulls it in
+                                        now so you can check the artwork before saving.
+                                    </div>
+                                    <p
+                                        v-if="fetchMessage"
+                                        class="text-sm mt-2"
+                                        :class="fetchFailed ? 'text-red-400' : 'text-gray-400'"
+                                    >
+                                        {{ fetchMessage }}
+                                    </p>
+
+                                    <div v-if="fetchedArtwork" class="mt-3 flex items-start gap-3">
+                                        <img
+                                            :src="fetchedArtwork"
+                                            alt="Artwork from TMDB"
+                                            width="120"
+                                            class="rounded-sm"
+                                        />
+                                        <div class="text-gray-400 text-sm">
+                                            Artwork found on TMDB. It is downloaded and resized when
+                                            you save.
+                                        </div>
                                     </div>
                                 </div>
 
@@ -384,12 +422,17 @@
 <script>
 import axios from 'axios';
 import MainNav from '../partials/MainNav.vue';
+import TitleLookup from '@/components/title-lookup.vue';
 
 export default {
     data: function () {
         return {
             loading: false,
             saving: false,
+            fetching: false,
+            fetchMessage: '',
+            fetchFailed: false,
+            fetchedArtwork: '',
             errors: [],
             recaching: false,
             debounce: false,
@@ -416,9 +459,72 @@ export default {
             socket: '',
         };
     },
-    components: { MainNav },
+    components: { MainNav, TitleLookup },
     watch: {},
     methods: {
+        /**
+         * Fill the form in from a title the operator picked in the search
+         * results, or fetched by IMDB id.
+         */
+        applyTitle(title) {
+            this.poster.imdb_id = title.imdb_id || this.poster.imdb_id;
+            this.poster.media_type = title.media_type || this.poster.media_type;
+            this.poster.name = title.title || this.poster.name;
+
+            if (title.mpaa_rating) {
+                this.poster.mpaa_rating = title.mpaa_rating;
+            }
+            if (title.audience_rating !== null && title.audience_rating !== undefined) {
+                this.poster.audience_rating = title.audience_rating;
+            }
+            if (title.runtime) {
+                this.poster.runtime = title.runtime;
+            }
+            if (title.trailer_id) {
+                this.poster.trailer_path = title.trailer_id;
+            }
+
+            this.fetchedArtwork = title.preview_url || '';
+            this.fetchFailed = false;
+            this.fetchMessage = title.imdb_id
+                ? 'Filled in from TMDB. Check it over, then save.'
+                : 'Filled in from TMDB, but it has no IMDB ID - the artwork will not re-download on save.';
+        },
+
+        /**
+         * Pull the artwork and metadata for the IMDB ID already in the field,
+         * so it can be checked before saving rather than appearing afterwards.
+         */
+        fetchMedia() {
+            const imdbId = (this.poster.imdb_id || '').trim();
+
+            if (!imdbId) {
+                this.fetchFailed = true;
+                this.fetchMessage = 'Enter an IMDB ID first, or use the search above.';
+                return;
+            }
+
+            this.fetching = true;
+            this.fetchMessage = '';
+            this.fetchFailed = false;
+            this.fetchedArtwork = '';
+
+            axios
+                .get('/api/tmdb/title', {
+                    params: { imdb_id: imdbId, media_type: this.poster.media_type },
+                })
+                .then(({ data }) => this.applyTitle(data.title))
+                .catch((error) => {
+                    const body = error.response && error.response.data;
+                    this.fetchFailed = true;
+                    this.fetchMessage =
+                        (body && body.message) || 'Could not fetch that title. Please try again.';
+                })
+                .finally(() => {
+                    this.fetching = false;
+                });
+        },
+
         getPoster(id) {
             axios
                 .get('/api/posters/' + id)

--- a/resources/js/components/title-lookup.vue
+++ b/resources/js/components/title-lookup.vue
@@ -1,0 +1,184 @@
+<template>
+    <div class="mb-5">
+        <label class="text-gray-300 block mb-2 font-bold" for="title-search">
+            Find a title
+        </label>
+
+        <div class="flex gap-2">
+            <input
+                id="title-search"
+                v-model="term"
+                type="text"
+                class="text-black w-full"
+                placeholder="Search by name, e.g. Blade Runner"
+                @keydown.enter.prevent="search"
+            />
+            <button
+                type="button"
+                class="btn text-black bg-gray-300 px-4 rounded-sm hover:bg-gray-100 whitespace-nowrap"
+                :disabled="busy"
+                @click.prevent="search"
+            >
+                {{ busy ? 'Searching…' : 'Search' }}
+            </button>
+        </div>
+        <div class="text-gray-400 text-sm mt-1">
+            Searches TMDB, which is where the poster data comes from. Picking a result fills in
+            the IMDB ID and the rest of the fields below.
+        </div>
+
+        <p v-if="message" class="text-sm mt-2" :class="messageClass">{{ message }}</p>
+
+        <ul v-if="results.length" class="mt-3 max-h-96 overflow-y-auto rounded-sm">
+            <li
+                v-for="result in results"
+                :key="result.tmdb_id"
+                class="flex items-center gap-3 p-2 cursor-pointer border-b border-gray-700"
+                :class="selected && selected.tmdb_id === result.tmdb_id ? 'bg-blue-900' : 'hover:bg-gray-800'"
+                @click="selected = result"
+            >
+                <img
+                    v-if="result.thumbnail"
+                    :src="result.thumbnail"
+                    :alt="result.title"
+                    width="46"
+                    height="69"
+                    class="shrink-0 rounded-sm"
+                    loading="lazy"
+                />
+                <span
+                    v-else
+                    class="shrink-0 flex items-center justify-center text-gray-500 text-xs bg-gray-800 rounded-sm"
+                    style="width: 46px; height: 69px"
+                >
+                    No art
+                </span>
+
+                <span class="grow">
+                    <span class="text-white block">{{ result.title }}</span>
+                    <span class="text-gray-400 text-sm">
+                        {{ result.year || 'Year unknown' }} ·
+                        {{ result.media_type === 'tv' ? 'TV' : 'Movie' }}
+                    </span>
+                </span>
+
+                <span v-if="selected && selected.tmdb_id === result.tmdb_id" class="text-white pr-2">
+                    Selected
+                </span>
+            </li>
+        </ul>
+
+        <div v-if="selected" class="mt-3 flex items-center gap-3">
+            <button
+                type="button"
+                class="btn text-white px-4 py-1 rounded-sm"
+                style="background-color: #2563eb"
+                :disabled="busy"
+                @click.prevent="confirm"
+            >
+                {{ busy ? 'Fetching…' : 'Use “' + selected.title + '”' }}
+            </button>
+            <button
+                type="button"
+                class="btn text-gray-300 px-3 py-1 rounded-sm hover:text-white"
+                @click.prevent="reset"
+            >
+                Cancel
+            </button>
+        </div>
+    </div>
+</template>
+
+<script>
+import axios from 'axios';
+
+export default {
+    name: 'TitleLookup',
+    props: {
+        mediaType: {
+            type: String,
+            default: 'movie',
+        },
+    },
+    emits: ['selected'],
+    data() {
+        return {
+            term: '',
+            results: [],
+            selected: null,
+            busy: false,
+            message: '',
+            messageIsError: false,
+        };
+    },
+    computed: {
+        messageClass() {
+            return this.messageIsError ? 'text-red-400' : 'text-gray-400';
+        },
+    },
+    methods: {
+        reset() {
+            this.results = [];
+            this.selected = null;
+            this.message = '';
+            this.messageIsError = false;
+        },
+        say(text, isError = false) {
+            this.message = text;
+            this.messageIsError = isError;
+        },
+        search() {
+            if (this.term.trim().length < 2) {
+                this.say('Type at least two characters to search.', true);
+                return;
+            }
+
+            this.busy = true;
+            this.reset();
+
+            axios
+                .get('/api/tmdb/search', {
+                    params: { query: this.term.trim(), media_type: this.mediaType },
+                })
+                .then(({ data }) => {
+                    this.results = data.results;
+                    if (this.results.length === 0) {
+                        this.say('Nothing matched that title.');
+                    }
+                })
+                .catch((error) => this.say(this.readError(error), true))
+                .finally(() => {
+                    this.busy = false;
+                });
+        },
+        confirm() {
+            if (!this.selected) {
+                return;
+            }
+
+            this.busy = true;
+
+            axios
+                .get('/api/tmdb/title', {
+                    params: {
+                        tmdb_id: this.selected.tmdb_id,
+                        media_type: this.selected.media_type,
+                    },
+                })
+                .then(({ data }) => {
+                    this.$emit('selected', data.title);
+                    this.term = '';
+                    this.reset();
+                })
+                .catch((error) => this.say(this.readError(error), true))
+                .finally(() => {
+                    this.busy = false;
+                });
+        },
+        readError(error) {
+            const data = error.response && error.response.data;
+            return (data && data.message) || 'The lookup failed. Please try again.';
+        },
+    },
+};
+</script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\AuthController;
 use App\Http\Controllers\NowPlayingController;
 use App\Http\Controllers\PosterController;
 use App\Http\Controllers\SettingController;
+use App\Http\Controllers\TmdbController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -63,6 +64,10 @@ Route::middleware('dmp.auth')->group(function () {
     Route::post('/show-in-rotation', [PosterController::class, 'showInRotation']);
 
     Route::get('/service-sections/{service}', [PosterController::class, 'getServiceSections']);
+
+    // Title lookup for the poster editor. Spends the operator's TMDB key.
+    Route::get('/tmdb/search', [TmdbController::class, 'search']);
+    Route::get('/tmdb/title', [TmdbController::class, 'title']);
 
     Route::get('/cache-posters', [ApiController::class, 'cache']);
     Route::post('/now-playing', [ApiController::class, 'dmpBroadcast']);

--- a/tests/Feature/TmdbLookupTest.php
+++ b/tests/Feature/TmdbLookupTest.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Services\PosterService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * Title search and lookup for the poster editor.
+ *
+ * DMP keys posters on IMDB ids, but IMDB has no public API - TMDB answers, and
+ * accepts IMDB ids as well as its own.
+ */
+class TmdbLookupTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Setting::firstOrFail()->forceFill(['tmdb_api_key_v3' => 'test-key'])->save();
+    }
+
+    public function test_searching_by_title_returns_pickable_results(): void
+    {
+        Http::fake(['*/search/movie*' => Http::response(['results' => [
+            [
+                'id' => 78,
+                'title' => 'Blade Runner',
+                'release_date' => '1982-06-25',
+                'overview' => 'A blade runner must pursue replicants.',
+                'vote_average' => 8.1,
+                'poster_path' => '/blade.jpg',
+            ],
+            [
+                'id' => 335984,
+                'title' => 'Blade Runner 2049',
+                'release_date' => '2017-10-04',
+                'overview' => 'Thirty years later.',
+                'vote_average' => 7.5,
+                'poster_path' => '/2049.jpg',
+            ],
+        ]])]);
+
+        $response = $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=blade+runner&media_type=movie')
+            ->assertOk();
+
+        $response->assertJsonPath('results.0.title', 'Blade Runner')
+            ->assertJsonPath('results.0.year', '1982')
+            ->assertJsonPath('results.0.media_type', 'movie')
+            ->assertJsonPath('results.0.tmdb_id', 78)
+            ->assertJsonPath('results.1.year', '2017');
+
+        // Enough to tell two same-named titles apart at a glance.
+        $this->assertStringContainsString('/w154/blade.jpg', $response->json('results.0.thumbnail'));
+    }
+
+    public function test_a_search_with_no_matches_is_an_empty_list_not_an_error(): void
+    {
+        Http::fake(['*/search/movie*' => Http::response(['results' => []])]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=nothing+matches+this')
+            ->assertOk()
+            ->assertJsonPath('results', []);
+    }
+
+    public function test_tv_search_reads_the_show_fields(): void
+    {
+        Http::fake(['*/search/tv*' => Http::response(['results' => [
+            ['id' => 1399, 'name' => 'Game of Thrones', 'first_air_date' => '2011-04-17', 'poster_path' => '/got.jpg'],
+        ]])]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=thrones&media_type=tv')
+            ->assertOk()
+            ->assertJsonPath('results.0.title', 'Game of Thrones')
+            ->assertJsonPath('results.0.year', '2011')
+            ->assertJsonPath('results.0.media_type', 'tv');
+    }
+
+    public function test_a_search_needs_a_couple_of_characters(): void
+    {
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=a')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('query');
+    }
+
+    public function test_picking_a_result_returns_everything_the_form_needs(): void
+    {
+        Http::fake(['*/movie/78*' => Http::response([
+            'id' => 78,
+            'title' => 'Blade Runner',
+            'release_date' => '1982-06-25',
+            'runtime' => 117,
+            'vote_average' => 8.1,
+            'poster_path' => '/blade.jpg',
+            'external_ids' => ['imdb_id' => 'tt0083658'],
+            'release_dates' => ['results' => [
+                ['iso_3166_1' => 'GB', 'release_dates' => [['certification' => '15']]],
+                ['iso_3166_1' => 'US', 'release_dates' => [['certification' => 'R']]],
+            ]],
+            'videos' => ['results' => [
+                ['type' => 'Teaser', 'site' => 'YouTube', 'official' => true, 'key' => 'teaser'],
+                ['type' => 'Trailer', 'site' => 'YouTube', 'official' => true, 'key' => 'the-trailer'],
+            ]],
+        ])]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/title?tmdb_id=78&media_type=movie')
+            ->assertOk()
+            ->assertJsonPath('title.imdb_id', 'tt0083658')
+            ->assertJsonPath('title.title', 'Blade Runner')
+            ->assertJsonPath('title.runtime', 117)
+            ->assertJsonPath('title.mpaa_rating', 'R')      // US certification, not GB
+            ->assertJsonPath('title.trailer_id', 'the-trailer')
+            ->assertJsonPath('title.year', '1982');
+    }
+
+    public function test_fetching_by_imdb_id_resolves_through_find(): void
+    {
+        Http::fake([
+            '*/find/tt0083658*' => Http::response(['movie_results' => [['id' => 78]]]),
+            '*/movie/78*' => Http::response([
+                'id' => 78, 'title' => 'Blade Runner', 'poster_path' => '/blade.jpg',
+                'external_ids' => ['imdb_id' => 'tt0083658'],
+            ]),
+        ]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/title?imdb_id=tt0083658&media_type=movie')
+            ->assertOk()
+            ->assertJsonPath('title.title', 'Blade Runner')
+            ->assertJsonPath('title.tmdb_id', 78);
+    }
+
+    public function test_an_unknown_imdb_id_says_so_plainly(): void
+    {
+        Http::fake(['*/find/*' => Http::response(['movie_results' => []])]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/title?imdb_id=tt9999999&media_type=movie')
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'No movie on TMDB has the IMDB id tt9999999.');
+    }
+
+    public function test_a_missing_api_key_is_reported_not_a_crash(): void
+    {
+        Setting::firstOrFail()->forceFill(['tmdb_api_key_v3' => null])->save();
+        Http::fake();
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=blade+runner')
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'No TMDB API key is set. Add one in Settings.');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_a_rejected_api_key_is_reported(): void
+    {
+        Http::fake(['*' => Http::response(['status_message' => 'Invalid API key'], 401)]);
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=blade+runner')
+            ->assertStatus(422)
+            ->assertJsonPath('message', 'TMDB rejected the API key. Check it in Settings.');
+    }
+
+    public function test_an_unreachable_tmdb_is_a_502(): void
+    {
+        Http::fake(fn () => throw new ConnectionException('refused'));
+
+        $this->actingAsAdmin()
+            ->getJson('/api/tmdb/search?query=blade+runner')
+            ->assertStatus(502)
+            ->assertJsonStructure(['message']);
+    }
+
+    public function test_the_lookup_endpoints_require_authentication(): void
+    {
+        Http::fake();
+
+        $this->getJson('/api/tmdb/search?query=blade+runner')->assertUnauthorized();
+        $this->getJson('/api/tmdb/title?imdb_id=tt0083658')->assertUnauthorized();
+
+        Http::assertNothingSent();
+    }
+
+    public function test_saving_a_poster_still_uses_the_same_lookup(): void
+    {
+        // The save path was rewired onto TmdbService; this guards that it still
+        // populates a poster from an IMDB id.
+        Http::fake([
+            '*/find/tt0083658*' => Http::response(['movie_results' => [['id' => 78]]]),
+            '*/movie/78*' => Http::response([
+                'id' => 78, 'title' => 'Blade Runner', 'runtime' => 117, 'vote_average' => 8.1,
+                'poster_path' => '/blade.jpg', 'external_ids' => ['imdb_id' => 'tt0083658'],
+                'release_dates' => ['results' => [['iso_3166_1' => 'US', 'release_dates' => [['certification' => 'R']]]]],
+            ]),
+            'image.tmdb.org/*' => Http::response($this->pngBytes(), 200),
+        ]);
+
+        $meta = app(PosterService::class)->posterMeta('tt0083658', 'movie');
+
+        $this->assertTrue($meta['success']);
+        $this->assertSame('Blade Runner', $meta['title']);
+        $this->assertSame('R', $meta['mpaa_rating']);
+        $this->assertSame(117, $meta['runtime']);
+    }
+
+    private function pngBytes(): string
+    {
+        $image = imagecreatetruecolor(10, 10);
+        ob_start();
+        imagepng($image);
+
+        return (string) ob_get_clean();
+    }
+}


### PR DESCRIPTION
Two additions to the poster editor.

### Find a title

Adding a poster meant knowing its IMDB ID up front. You can now search by name;
results show artwork, year and movie/TV, which is what actually distinguishes a
remake from the original:

```
Blade Runner              1982 · Movie
Blade Runner 2049         2017 · Movie
Blade Runner: Black Out   2017 · Movie
```

Pick one, confirm, and the IMDB ID, title, rating, audience score, runtime and
trailer are filled in.

### Fetch media

Artwork only appeared *after* saving, so a wrong ID was not obvious until
afterwards. "Fetch media" pulls it in straight away and shows the poster, so it
can be checked first. Saving still downloads, resizes and converts as before.

### One TMDB client

`PosterProcess` carried its own copy of the TMDB HTTP calls, response shaping
and rating extraction. Both new features and the existing save-time lookup now
go through `TmdbService`, so they cannot disagree about what a title looks like
— about 110 lines out of the trait.

### Worth stating plainly

**This is TMDB, not IMDB.** IMDB has no public API. TMDB is what already
answered for the existing IMDB-ID lookups; it accepts IMDB IDs and returns them,
so the identifiers you use are unchanged.

Search deliberately does not resolve an IMDB ID per result — that is one extra
request per row, and only the title actually chosen needs one.

A missing key, a rejected key, an unknown ID and an unreachable TMDB each come
back as something the operator can act on. Endpoints are behind the usual admin
gate, since they spend the operator's API key.

### Verified

12 new tests (147 total). In a browser against a stubbed TMDB: search
distinguishes the 1982 and 2017 films, confirming fills every field
(`R`, `7.5`, `164 min`, trailer ID), Fetch media swaps titles, and a bad ID
shows the reason without clearing work already entered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)