### PR TITLE
Sign in with a username instead of an email address

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -113,6 +113,12 @@ First run offers to create the admin account, since an appliance has no other
 way to bootstrap one; that path closes permanently as soon as a user exists,
 and `DMP_ALLOW_SETUP=false` disables it in favour of `php artisan dmp:user`.
 
+The account is a username and a password. It carried an email address and a
+display name until it became clear nothing used them: no mailer is configured,
+there is no password reset and no verification, so the address was a login name
+that had to look like an address - and implied an account recovery that does
+not exist. The `password_resets` table went with it.
+
 One deliberate exception, because the kiosk browser cannot log in: the
 endpoints the display polls (`/api/posters`, `/api/settings`,
 `/api/now-playing/*`) stay open. They return no credentials — see #1.

--- a/README.md
+++ b/README.md
@@ -237,13 +237,19 @@ affected.
 
 ## Security
 
-The admin UI requires a login. The first time you open it on a new device it
-offers to create the administrator account; after that the same screen asks you
-to sign in. You can also manage the account from the console:
+The admin UI requires a login - a username and a password. The first time you
+open it on a new device it offers to create the administrator account; after
+that the same screen asks you to sign in. You can also manage the account from
+the console:
 
 ```bash
-php artisan dmp:user
+php artisan dmp:user                     # prompts
+php artisan dmp:user --username=mike     # prompts for the password only
 ```
+
+There is no email address on the account and no password reset: the device
+sends no mail, so an address would only be a login name that had to look like
+one. If you forget the password, `dmp:user` resets it from the console.
 
 Privileged endpoints — anything that writes, shells out, or returns credentials
 — accept either that session or a Sanctum bearer token, so integrations keep

--- a/README.md
+++ b/README.md
@@ -253,9 +253,11 @@ php artisan dmp:user                     # prompts
 php artisan dmp:user --username=mike     # prompts for the password only
 ```
 
-There is no email address on the account and no password reset: the device
-sends no mail, so an address would only be a login name that had to look like
-one. If you forget the password, `dmp:user` resets it from the console.
+You can also change your username and password from **Settings → Account**,
+which needs your current password. `dmp:user` is the way back in if you forget
+it, since there is no email address on the account and no password reset: the
+device sends no mail, so an address would only be a login name that had to look
+like one.
 
 Privileged endpoints — anything that writes, shells out, or returns credentials
 — accept either that session or a Sanctum bearer token, so integrations keep

--- a/app/Console/Commands/IssueApiToken.php
+++ b/app/Console/Commands/IssueApiToken.php
@@ -18,8 +18,7 @@ class IssueApiToken extends Command
 
         if (! $user) {
             $user = User::create([
-                'name' => 'DMP API',
-                'email' => 'api@digital-movie-poster.local',
+                'username' => 'dmp-api',
                 'password' => bcrypt(Str::random(40)),
             ]);
 

--- a/app/Console/Commands/ManageUser.php
+++ b/app/Console/Commands/ManageUser.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Password;
 
 /**
@@ -15,8 +16,7 @@ use Illuminate\Validation\Rules\Password;
 class ManageUser extends Command
 {
     protected $signature = 'dmp:user
-                            {--email= : Email address to sign in with}
-                            {--name= : Display name}
+                            {--username= : Username to sign in with}
                             {--password= : Password (prompted for if omitted)}';
 
     protected $description = 'Create the DMP admin account or reset its password';
@@ -25,19 +25,18 @@ class ManageUser extends Command
     {
         $existing = User::query()->first();
 
-        $email = $this->option('email')
-            ?: $this->ask('Email address', $existing?->email ?? 'admin@digital-movie-poster.local');
-
-        $name = $this->option('name')
-            ?: $this->ask('Display name', $existing?->name ?? 'Administrator');
+        $username = $this->option('username')
+            ?: $this->ask('Username', $existing?->username ?? 'admin');
 
         $password = $this->option('password') ?: $this->secret('Password');
 
         $validator = Validator::make(
-            ['email' => $email, 'name' => $name, 'password' => $password],
+            ['username' => $username, 'password' => $password],
             [
-                'email' => ['required', 'email', 'max:255'],
-                'name' => ['required', 'string', 'max:255'],
+                'username' => [
+                    'required', 'string', 'min:3', 'max:255', 'alpha_dash',
+                    Rule::unique('users', 'username')->ignore($existing?->id),
+                ],
                 'password' => ['required', 'string', Password::min(8)],
             ]
         );
@@ -52,20 +51,18 @@ class ManageUser extends Command
 
         if ($existing) {
             $existing->update([
-                'name' => $name,
-                'email' => $email,
+                'username' => $username,
                 'password' => Hash::make($password),
             ]);
 
-            $this->info('Updated the admin account ('.$email.').');
+            $this->info('Updated the admin account ('.$username.').');
         } else {
             User::create([
-                'name' => $name,
-                'email' => $email,
+                'username' => $username,
                 'password' => Hash::make($password),
             ]);
 
-            $this->info('Created the admin account ('.$email.').');
+            $this->info('Created the admin account ('.$username.').');
         }
 
         if (! config('dmp.auth.required')) {

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -28,20 +28,20 @@ class AuthController extends Controller
             'required' => (bool) config('dmp.auth.required'),
             'authenticated' => $request->user('sanctum') !== null,
             'needs_setup' => ! User::query()->exists() && (bool) config('dmp.auth.allow_setup'),
-            'user' => $request->user('sanctum')?->only(['id', 'name', 'email']),
+            'user' => $request->user('sanctum')?->only(['id', 'username']),
         ]);
     }
 
     public function login(Request $request): JsonResponse
     {
         $credentials = $request->validate([
-            'email' => ['required', 'string'],
+            'username' => ['required', 'string'],
             'password' => ['required', 'string'],
         ]);
 
         if (! Auth::attempt($credentials, $request->boolean('remember', true))) {
             throw ValidationException::withMessages([
-                'email' => 'Those credentials do not match our records.',
+                'username' => 'Those credentials do not match our records.',
             ]);
         }
 
@@ -49,7 +49,7 @@ class AuthController extends Controller
 
         return response()->json([
             'authenticated' => true,
-            'user' => $request->user()->only(['id', 'name', 'email']),
+            'user' => $request->user()->only(['id', 'username']),
         ]);
     }
 
@@ -84,14 +84,12 @@ class AuthController extends Controller
         }
 
         $data = $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'email', 'max:255'],
+            'username' => ['required', 'string', 'min:3', 'max:255', 'alpha_dash', 'unique:users,username'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
 
         $user = User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
+            'username' => $data['username'],
             'password' => Hash::make($data['password']),
         ]);
 
@@ -100,7 +98,7 @@ class AuthController extends Controller
 
         return response()->json([
             'authenticated' => true,
-            'user' => $user->only(['id', 'name', 'email']),
+            'user' => $user->only(['id', 'username']),
         ], 201);
     }
 }

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\ValidationException;
 
 /**
@@ -50,6 +51,46 @@ class AuthController extends Controller
         return response()->json([
             'authenticated' => true,
             'user' => $request->user()->only(['id', 'username']),
+        ]);
+    }
+
+    /**
+     * Change the signed-in account's username or password.
+     *
+     * DMP has one operator account, so this edits your own login and nothing
+     * else. The current password is required either way: a left-open browser
+     * should not be enough to take the account over.
+     */
+    public function updateAccount(Request $request): JsonResponse
+    {
+        $user = $request->user('sanctum');
+
+        $data = $request->validate([
+            'username' => [
+                'required', 'string', 'min:3', 'max:255', 'alpha_dash',
+                Rule::unique('users', 'username')->ignore($user->id),
+            ],
+            // Blank leaves the password alone.
+            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'current_password' => ['required', 'current_password'],
+        ]);
+
+        $user->username = $data['username'];
+
+        $changedPassword = ! empty($data['password']);
+
+        if ($changedPassword) {
+            $user->password = Hash::make($data['password']);
+        }
+
+        $user->save();
+
+        // Keep this browser signed in, but make the old session id useless.
+        $request->session()->regenerate();
+
+        return response()->json([
+            'user' => $user->only(['id', 'username']),
+            'password_changed' => $changedPassword,
         ]);
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,24 +7,26 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
+/**
+ * The single operator account.
+ *
+ * Signs in with a username: the device sends no mail, so an email address
+ * would only ever be a login name that had to look like an address, and would
+ * imply a password reset that does not exist.
+ */
 class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
     /**
-     * The attributes that are mass assignable.
-     *
      * @var list<string>
      */
     protected $fillable = [
-        'name',
-        'email',
+        'username',
         'password',
     ];
 
     /**
-     * The attributes that should be hidden for serialization.
-     *
      * @var list<string>
      */
     protected $hidden = [
@@ -33,14 +35,11 @@ class User extends Authenticatable
     ];
 
     /**
-     * Get the attributes that should be cast.
-     *
      * @return array<string, string>
      */
     protected function casts(): array
     {
         return [
-            'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
     }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -27,18 +27,9 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
-            'email_verified_at' => now(),
+            'username' => fake()->unique()->userName(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
         ];
-    }
-
-    public function unverified(): static
-    {
-        return $this->state(fn (array $attributes) => [
-            'email_verified_at' => null,
-        ]);
     }
 }

--- a/database/migrations/2026_08_18_000002_replace_user_email_with_username.php
+++ b/database/migrations/2026_08_18_000002_replace_user_email_with_username.php
@@ -1,0 +1,108 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+/**
+ * Sign in with a username instead of an email address.
+ *
+ * DMP has one operator account on a device that sends no mail: there is no
+ * mailer configured, no password reset and no verification, so the email was
+ * only ever a login name that had to look like an address - and it implied an
+ * account recovery that does not exist. The display name went with it; on a
+ * single-account appliance the username is the label.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Each step is guarded: on SQLite a column change rebuilds the table,
+        // so a half-applied run has to be safe to repeat.
+        if (! Schema::hasColumn('users', 'username')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('username')->nullable()->after('id');
+            });
+        }
+
+        // Carry existing accounts across: the part before the @ is the closest
+        // thing to a username they already had.
+        foreach (DB::table('users')->whereNull('username')->get() as $user) {
+            $candidate = Str::of((string) ($user->email ?? ''))
+                ->before('@')
+                ->trim()
+                ->value();
+
+            if ($candidate === '') {
+                $candidate = 'admin';
+            }
+
+            $username = $candidate;
+            $suffix = 1;
+            while (DB::table('users')->where('username', $username)->where('id', '!=', $user->id)->exists()) {
+                $username = $candidate.(++$suffix);
+            }
+
+            DB::table('users')->where('id', $user->id)->update(['username' => $username]);
+        }
+
+        $indexes = collect(Schema::getIndexes('users'))->pluck('name');
+
+        if (! $indexes->contains('users_username_unique')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->unique('username');
+            });
+        }
+
+        // SQLite refuses to drop a column an index still refers to, so the
+        // email unique index has to go first.
+        DB::statement('DROP INDEX IF EXISTS users_email_unique');
+
+        Schema::table('users', function (Blueprint $table) {
+            foreach (['email', 'email_verified_at', 'name'] as $column) {
+                if (Schema::hasColumn('users', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+
+        // Only ever existed to support emailed password resets.
+        Schema::dropIfExists('password_resets');
+        Schema::dropIfExists('password_reset_tokens');
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (! Schema::hasColumn('users', 'name')) {
+                $table->string('name')->nullable();
+            }
+            if (! Schema::hasColumn('users', 'email')) {
+                $table->string('email')->nullable();
+            }
+            if (! Schema::hasColumn('users', 'email_verified_at')) {
+                $table->timestamp('email_verified_at')->nullable();
+            }
+        });
+
+        foreach (DB::table('users')->get() as $user) {
+            DB::table('users')->where('id', $user->id)->update([
+                'name' => $user->username,
+                'email' => $user->username.'@digital-movie-poster.local',
+            ]);
+        }
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique(['username']);
+            $table->dropColumn('username');
+        });
+
+        Schema::create('password_resets', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+};

--- a/resources/js/Views/Login.vue
+++ b/resources/js/Views/Login.vue
@@ -12,40 +12,29 @@
                 </h2>
                 <p class="text-sm text-gray-400 mb-6">
                     <template v-if="isSetup">
-                        This device does not have an account yet. The first one you create
-                        becomes the administrator.
+                        This device does not have an account yet. Pick a username and
+                        password; the first account created becomes the administrator.
                     </template>
                     <template v-else>Sign in to manage posters and settings.</template>
                 </p>
 
                 <form @submit.prevent="submit">
-                    <div v-if="isSetup" class="mb-4">
-                        <label class="block text-sm text-gray-300 mb-1" for="name">Name</label>
-                        <input
-                            id="name"
-                            v-model="form.name"
-                            type="text"
-                            autocomplete="name"
-                            class="w-full rounded"
-                            required
-                        />
-                        <p v-if="errorFor('name')" class="text-red-400 text-sm mt-1">
-                            {{ errorFor('name') }}
-                        </p>
-                    </div>
-
                     <div class="mb-4">
-                        <label class="block text-sm text-gray-300 mb-1" for="email">Email</label>
+                        <label class="block text-sm text-gray-300 mb-1" for="username">
+                            Username
+                        </label>
                         <input
-                            id="email"
-                            v-model="form.email"
-                            type="email"
+                            id="username"
+                            v-model="form.username"
+                            type="text"
                             autocomplete="username"
+                            autocapitalize="none"
+                            spellcheck="false"
                             class="w-full rounded"
                             required
                         />
-                        <p v-if="errorFor('email')" class="text-red-400 text-sm mt-1">
-                            {{ errorFor('email') }}
+                        <p v-if="errorFor('username')" class="text-red-400 text-sm mt-1">
+                            {{ errorFor('username') }}
                         </p>
                     </div>
 
@@ -108,7 +97,7 @@ export default {
     name: 'Login',
     data() {
         return {
-            form: { name: '', email: '', password: '', password_confirmation: '' },
+            form: { username: '', password: '', password_confirmation: '' },
             errors: {},
             generalError: '',
             busy: false,
@@ -136,7 +125,10 @@ export default {
                 if (this.isSetup) {
                     await auth.setup(this.form);
                 } else {
-                    await auth.login({ email: this.form.email, password: this.form.password });
+                    await auth.login({
+                        username: this.form.username,
+                        password: this.form.password,
+                    });
                 }
 
                 const redirect = this.$route.query.redirect || '/posters';

--- a/resources/js/Views/Settings.vue
+++ b/resources/js/Views/Settings.vue
@@ -33,6 +33,14 @@
                                         >Poster Sources</a
                                     >
                                 </li>
+                                <li>
+                                    <a
+                                        href="#account"
+                                        class="text-sm md:text-md"
+                                        @click.prevent="setTab($event)"
+                                        >Account</a
+                                    >
+                                </li>
                             </ul>
 
                             <div class="settings-bar-actions">
@@ -1297,6 +1305,108 @@
                                     <div id="kodipassHelp" class="text-gray-400 text-sm"></div>
                                 </div>
                             </div>
+                            <div id="account" class="tab-content">
+                                <p class="text-gray-400 text-sm mb-7">
+                                    DMP has a single operator account. This changes the login you
+                                    are signed in with; it does not affect API tokens, which are
+                                    issued from the console with
+                                    <code class="text-gray-300">php artisan dmp:token</code>.
+                                </p>
+
+                                <div class="mb-5">
+                                    <label for="account-username" class="text-gray-300 block mb-2 font-bold">
+                                        Username
+                                    </label>
+                                    <input
+                                        type="text"
+                                        class="text-black w-full"
+                                        id="account-username"
+                                        v-model="account.username"
+                                        autocomplete="username"
+                                        autocapitalize="none"
+                                        spellcheck="false"
+                                    />
+                                    <div class="text-gray-400 text-sm">
+                                        Letters, numbers, dashes and underscores. At least three
+                                        characters.
+                                    </div>
+                                </div>
+
+                                <hr class="mt-3 mb-7 border-gray-700" />
+
+                                <h3 class="text-white font-bold text-lg mb-1">Change password</h3>
+                                <p class="text-gray-400 text-sm mb-5">
+                                    Leave these blank to keep your current password.
+                                </p>
+
+                                <div class="mb-5">
+                                    <label for="account-password" class="text-gray-300 block mb-2 font-bold">
+                                        New password
+                                    </label>
+                                    <input
+                                        type="password"
+                                        class="text-black w-full"
+                                        id="account-password"
+                                        v-model="account.password"
+                                        autocomplete="new-password"
+                                    />
+                                    <div class="text-gray-400 text-sm">At least eight characters.</div>
+                                </div>
+
+                                <div class="mb-5">
+                                    <label for="account-password-confirm" class="text-gray-300 block mb-2 font-bold">
+                                        Confirm new password
+                                    </label>
+                                    <input
+                                        type="password"
+                                        class="text-black w-full"
+                                        id="account-password-confirm"
+                                        v-model="account.password_confirmation"
+                                        autocomplete="new-password"
+                                    />
+                                </div>
+
+                                <hr class="mt-3 mb-7 border-gray-700" />
+
+                                <div class="mb-5">
+                                    <label for="account-current" class="text-gray-300 block mb-2 font-bold">
+                                        Current password
+                                    </label>
+                                    <input
+                                        type="password"
+                                        class="text-black w-full"
+                                        id="account-current"
+                                        v-model="account.current_password"
+                                        autocomplete="current-password"
+                                    />
+                                    <div class="text-gray-400 text-sm">
+                                        Required to save any change here, so a browser left open is
+                                        not enough to take the account over.
+                                    </div>
+                                </div>
+
+                                <div
+                                    v-if="accountMessage"
+                                    class="px-4 py-3 rounded mb-4"
+                                    :class="accountFailed ? 'bg-red-900 text-white' : 'bg-green-900 text-white'"
+                                    role="alert"
+                                >
+                                    <p>{{ accountMessage }}</p>
+                                    <div v-for="(err, i) in accountErrors" :key="'acct-' + i">
+                                        {{ err }}
+                                    </div>
+                                </div>
+
+                                <button
+                                    type="button"
+                                    class="btn text-white px-4 py-2 rounded-sm"
+                                    style="background-color: #2563eb"
+                                    :disabled="savingAccount"
+                                    @click.prevent="saveAccount"
+                                >
+                                    {{ savingAccount ? 'Updating…' : 'Update account' }}
+                                </button>
+                            </div>
                         </div>
                         <!-- / .tabs-content -->
 
@@ -1311,6 +1421,7 @@
 import axios from 'axios';
 import { io } from 'socket.io-client';
 import MainNav from '@/partials/MainNav.vue';
+import { useAuthStore } from '@/store/auth';
 
 export default {
     data: function () {
@@ -1326,6 +1437,16 @@ export default {
             savedSnapshot: '',
             // The navigation held back while the unsaved-changes prompt is up.
             pendingLeave: null,
+            account: {
+                username: '',
+                password: '',
+                password_confirmation: '',
+                current_password: '',
+            },
+            savingAccount: false,
+            accountMessage: '',
+            accountFailed: false,
+            accountErrors: [],
             settings: {
                 plex_token: '',
                 plex_ip_address: '',
@@ -1480,6 +1601,53 @@ export default {
             event.preventDefault();
             event.returnValue = '';
         },
+        /**
+         * The account form is deliberately separate from the settings save
+         * bar: it posts elsewhere, needs the current password, and should not
+         * be swept along by "Save settings".
+         */
+        saveAccount() {
+            if (this.savingAccount) {
+                return;
+            }
+
+            this.savingAccount = true;
+            this.accountMessage = '';
+            this.accountFailed = false;
+            this.accountErrors = [];
+
+            axios
+                .put('/api/auth/account', this.account)
+                .then(({ data }) => {
+                    this.accountMessage = data.password_changed
+                        ? 'Account updated. Your new password applies the next time you sign in.'
+                        : 'Account updated.';
+                    this.account.password = '';
+                    this.account.password_confirmation = '';
+                    this.account.current_password = '';
+                    useAuthStore().loadStatus(true);
+                })
+                .catch((error) => {
+                    this.accountFailed = true;
+                    const body = error.response && error.response.data;
+                    this.accountMessage = (body && body.message) || 'The account could not be updated.';
+
+                    const errors = (body && body.errors) || {};
+                    Object.keys(errors).forEach((field) => {
+                        if (errors[field] instanceof Array) {
+                            errors[field].forEach((err) => this.accountErrors.push(err));
+                        }
+                    });
+
+                    // Laravel repeats the first error in "message".
+                    if (this.accountErrors.length) {
+                        this.accountMessage = 'That change could not be saved:';
+                    }
+                })
+                .finally(() => {
+                    this.savingAccount = false;
+                });
+        },
         markClean() {
             this.savedSnapshot = JSON.stringify(this.settings);
         },
@@ -1599,6 +1767,11 @@ export default {
             this.socket = io('http://' + location.hostname + ':3000');
         }
         window.addEventListener('beforeunload', this.warnBeforeUnload);
+
+        const auth = useAuthStore();
+        Promise.resolve(auth.loadStatus()).then(() => {
+            this.account.username = auth.user ? auth.user.username : '';
+        });
     },
     beforeUnmount() {
         window.removeEventListener('beforeunload', this.warnBeforeUnload);

--- a/resources/js/Views/Settings.vue
+++ b/resources/js/Views/Settings.vue
@@ -1307,10 +1307,7 @@
                             </div>
                             <div id="account" class="tab-content">
                                 <p class="text-gray-400 text-sm mb-7">
-                                    DMP has a single operator account. This changes the login you
-                                    are signed in with; it does not affect API tokens, which are
-                                    issued from the console with
-                                    <code class="text-gray-300">php artisan dmp:token</code>.
+                                    Change the username and password you sign in with.
                                 </p>
 
                                 <div class="mb-5">

--- a/resources/js/partials/MainNav.vue
+++ b/resources/js/partials/MainNav.vue
@@ -94,7 +94,7 @@ export default {
             return this.required && this.authenticated;
         },
         userName() {
-            return this.user ? this.user.name : '';
+            return this.user ? this.user.username : '';
         },
     },
     methods: {

--- a/routes/api.php
+++ b/routes/api.php
@@ -52,6 +52,9 @@ Route::get('/kodi-now-playing', [ApiController::class, 'kodiNowPlaying']);
 */
 
 Route::middleware('dmp.auth')->group(function () {
+    // Change your own username or password. Requires the current password.
+    Route::put('/auth/account', [AuthController::class, 'updateAccount']);
+
     // Returns the full settings row, credentials included, for the admin UI.
     Route::get('/settings/full', [SettingController::class, 'full']);
     Route::put('/settings', [SettingController::class, 'update']);

--- a/tests/Feature/AccountManagementTest.php
+++ b/tests/Feature/AccountManagementTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+/**
+ * Editing your own login from the settings page, so a password change does not
+ * require console access to the device.
+ */
+class AccountManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function signedIn(string $password = 'correct-horse'): User
+    {
+        $user = User::factory()->create([
+            'username' => 'operator',
+            'password' => Hash::make($password),
+        ]);
+
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    public function test_the_username_can_be_changed(): void
+    {
+        $user = $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'newname',
+            'current_password' => 'correct-horse',
+        ])->assertOk()->assertJsonPath('user.username', 'newname');
+
+        $this->assertSame('newname', $user->fresh()->username);
+    }
+
+    public function test_the_password_can_be_changed(): void
+    {
+        $user = $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'operator',
+            'password' => 'a-brand-new-password',
+            'password_confirmation' => 'a-brand-new-password',
+            'current_password' => 'correct-horse',
+        ])->assertOk()->assertJsonPath('password_changed', true);
+
+        $this->assertTrue(Hash::check('a-brand-new-password', $user->fresh()->password));
+    }
+
+    public function test_leaving_the_password_blank_keeps_the_existing_one(): void
+    {
+        $user = $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'renamed',
+            'password' => '',
+            'current_password' => 'correct-horse',
+        ])->assertOk()->assertJsonPath('password_changed', false);
+
+        $this->assertTrue(Hash::check('correct-horse', $user->fresh()->password));
+        $this->assertSame('renamed', $user->fresh()->username);
+    }
+
+    public function test_the_current_password_is_required(): void
+    {
+        $user = $this->signedIn();
+
+        $this->putJson('/api/auth/account', ['username' => 'newname'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('current_password');
+
+        $this->assertSame('operator', $user->fresh()->username);
+    }
+
+    public function test_a_wrong_current_password_changes_nothing(): void
+    {
+        $user = $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'newname',
+            'password' => 'a-brand-new-password',
+            'password_confirmation' => 'a-brand-new-password',
+            'current_password' => 'not-the-password',
+        ])->assertStatus(422)->assertJsonValidationErrors('current_password');
+
+        $this->assertSame('operator', $user->fresh()->username);
+        $this->assertTrue(Hash::check('correct-horse', $user->fresh()->password));
+    }
+
+    public function test_a_new_password_must_be_confirmed_and_long_enough(): void
+    {
+        $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'operator',
+            'password' => 'short',
+            'password_confirmation' => 'mismatch',
+            'current_password' => 'correct-horse',
+        ])->assertStatus(422)->assertJsonValidationErrors('password');
+    }
+
+    public function test_the_username_must_still_be_a_sensible_identifier(): void
+    {
+        $this->signedIn();
+
+        foreach (['ab', 'has spaces', 'has@symbol'] as $bad) {
+            $this->putJson('/api/auth/account', [
+                'username' => $bad,
+                'current_password' => 'correct-horse',
+            ])->assertStatus(422)->assertJsonValidationErrors('username');
+        }
+    }
+
+    public function test_keeping_your_own_username_is_not_a_uniqueness_clash(): void
+    {
+        $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'operator',
+            'current_password' => 'correct-horse',
+        ])->assertOk();
+    }
+
+    public function test_the_endpoint_requires_being_signed_in(): void
+    {
+        User::factory()->create(['username' => 'operator']);
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'newname',
+            'current_password' => 'correct-horse',
+        ])->assertUnauthorized();
+    }
+
+    public function test_the_session_survives_a_password_change(): void
+    {
+        $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'operator',
+            'password' => 'a-brand-new-password',
+            'password_confirmation' => 'a-brand-new-password',
+            'current_password' => 'correct-horse',
+        ])->assertOk();
+
+        // Still signed in: changing your own password should not lock you out
+        // of the browser you changed it from.
+        $this->getJson('/api/settings/full')->assertOk();
+    }
+
+    public function test_the_new_password_works_on_the_next_sign_in(): void
+    {
+        $this->signedIn();
+
+        $this->putJson('/api/auth/account', [
+            'username' => 'renamed',
+            'password' => 'a-brand-new-password',
+            'password_confirmation' => 'a-brand-new-password',
+            'current_password' => 'correct-horse',
+        ])->assertOk();
+
+        $this->postJson('/api/auth/logout')->assertOk();
+
+        $this->postJson('/api/auth/login', [
+            'username' => 'renamed',
+            'password' => 'a-brand-new-password',
+        ])->assertOk()->assertJsonPath('authenticated', true);
+    }
+}

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 class AuthTest extends TestCase
@@ -14,7 +15,7 @@ class AuthTest extends TestCase
     private function admin(string $password = 'correct-horse'): User
     {
         return User::factory()->create([
-            'email' => 'admin@example.test',
+            'username' => 'admin',
             'password' => Hash::make($password),
         ]);
     }
@@ -42,14 +43,13 @@ class AuthTest extends TestCase
     public function test_the_first_account_can_be_created_and_is_signed_in(): void
     {
         $this->postJson('/api/auth/setup', [
-            'name' => 'Mike',
-            'email' => 'mike@example.test',
+            'username' => 'mike',
             'password' => 'a-good-password',
             'password_confirmation' => 'a-good-password',
         ])->assertCreated()->assertJson(['authenticated' => true]);
 
         $this->assertAuthenticated();
-        $this->assertDatabaseHas('users', ['email' => 'mike@example.test']);
+        $this->assertDatabaseHas('users', ['username' => 'mike']);
     }
 
     public function test_setup_is_refused_once_an_account_exists(): void
@@ -57,8 +57,7 @@ class AuthTest extends TestCase
         $this->admin();
 
         $this->postJson('/api/auth/setup', [
-            'name' => 'Interloper',
-            'email' => 'someone@example.test',
+            'username' => 'interloper',
             'password' => 'a-good-password',
             'password_confirmation' => 'a-good-password',
         ])->assertStatus(409);
@@ -71,8 +70,7 @@ class AuthTest extends TestCase
         config(['dmp.auth.allow_setup' => false]);
 
         $this->postJson('/api/auth/setup', [
-            'name' => 'Mike',
-            'email' => 'mike@example.test',
+            'username' => 'mike',
             'password' => 'a-good-password',
             'password_confirmation' => 'a-good-password',
         ])->assertStatus(403);
@@ -83,8 +81,7 @@ class AuthTest extends TestCase
     public function test_setup_requires_a_confirmed_password_of_reasonable_length(): void
     {
         $this->postJson('/api/auth/setup', [
-            'name' => 'Mike',
-            'email' => 'mike@example.test',
+            'username' => 'mike',
             'password' => 'short',
             'password_confirmation' => 'nope',
         ])->assertStatus(422)->assertJsonValidationErrors('password');
@@ -95,7 +92,7 @@ class AuthTest extends TestCase
         $this->admin();
 
         $this->postJson('/api/auth/login', [
-            'email' => 'admin@example.test',
+            'username' => 'admin',
             'password' => 'correct-horse',
         ])->assertOk()->assertJson(['authenticated' => true]);
 
@@ -107,9 +104,9 @@ class AuthTest extends TestCase
         $this->admin();
 
         $this->postJson('/api/auth/login', [
-            'email' => 'admin@example.test',
+            'username' => 'admin',
             'password' => 'wrong',
-        ])->assertStatus(422)->assertJsonValidationErrors('email');
+        ])->assertStatus(422)->assertJsonValidationErrors('username');
 
         $this->assertGuest();
     }
@@ -122,7 +119,7 @@ class AuthTest extends TestCase
             ->assertUnauthorized();
 
         $this->postJson('/api/auth/login', [
-            'email' => 'admin@example.test',
+            'username' => 'admin',
             'password' => 'correct-horse',
         ])->assertOk();
 
@@ -152,7 +149,7 @@ class AuthTest extends TestCase
         }
 
         $this->postJson('/api/auth/login', [
-            'email' => 'admin@example.test',
+            'username' => 'admin',
             'password' => 'correct-horse',
         ])->assertStatus(429);
     }
@@ -160,16 +157,14 @@ class AuthTest extends TestCase
     public function test_the_artisan_command_creates_then_updates_the_single_account(): void
     {
         $this->artisan('dmp:user', [
-            '--email' => 'op@example.test',
-            '--name' => 'Operator',
+            '--username' => 'operator',
             '--password' => 'a-good-password',
         ])->assertSuccessful();
 
         $this->assertSame(1, User::count());
 
         $this->artisan('dmp:user', [
-            '--email' => 'op@example.test',
-            '--name' => 'Operator',
+            '--username' => 'operator',
             '--password' => 'a-different-password',
         ])->assertSuccessful();
 
@@ -177,11 +172,50 @@ class AuthTest extends TestCase
         $this->assertTrue(Hash::check('a-different-password', User::first()->password));
     }
 
+    public function test_a_username_must_be_a_sensible_identifier(): void
+    {
+        foreach (['ab', 'has spaces', 'has@symbol', ''] as $bad) {
+            $this->postJson('/api/auth/setup', [
+                'username' => $bad,
+                'password' => 'a-good-password',
+                'password_confirmation' => 'a-good-password',
+            ])->assertStatus(422)->assertJsonValidationErrors('username');
+        }
+
+        $this->assertSame(0, User::count());
+    }
+
+    public function test_a_username_can_contain_dashes_and_underscores(): void
+    {
+        $this->postJson('/api/auth/setup', [
+            'username' => 'movie_poster-admin',
+            'password' => 'a-good-password',
+            'password_confirmation' => 'a-good-password',
+        ])->assertCreated();
+
+        $this->assertDatabaseHas('users', ['username' => 'movie_poster-admin']);
+    }
+
+    public function test_the_account_never_carries_an_email(): void
+    {
+        // The device sends no mail, so there is nothing for an address to do.
+        $this->admin();
+
+        $this->assertNotContains('email', Schema::getColumnListing('users'));
+        $this->assertFalse(Schema::hasTable('password_resets'));
+
+        $body = $this->postJson('/api/auth/login', [
+            'username' => 'admin',
+            'password' => 'correct-horse',
+        ])->assertOk()->getContent();
+
+        $this->assertStringNotContainsString('email', $body);
+    }
+
     public function test_the_artisan_command_rejects_a_short_password(): void
     {
         $this->artisan('dmp:user', [
-            '--email' => 'op@example.test',
-            '--name' => 'Operator',
+            '--username' => 'operator',
             '--password' => 'short',
         ])->assertFailed();
 


### PR DESCRIPTION
**Nothing used the email.** I checked before changing anything:

- no `Mail::`, `Notification::` or mailable anywhere in `app/`
- no password reset flow — `routes/auth.php` was deleted in the refresh because it referenced controllers that never existed
- no email verification — `User` does not implement `MustVerifyEmail`
- `.env.example` has **zero** `MAIL_` variables; there is no mail configuration at all

So the address was only ever a login name that had to *look* like an address — and worse, it implied an account recovery that does not exist. The separate display name went too: on a single-account appliance the username is the label.

## Changes

- `users` gains a unique `username`; drops `email`, `email_verified_at`, `name`
- `password_resets` dropped — it existed only to support emailed resets
- Usernames are `alpha_dash`, 3–255 characters, unique
- `dmp:user --username=…`; the token command names its account `dmp-api`
- Login form asks for **Username**; setup is three fields instead of four
- Nav shows the username

## Existing installs

Carried across on the part before the `@`, so `operator@example.test` signs in
as **`operator`** with the same password. Verified on a real install.

The migration is written defensively because SQLite rebuilds the table on a
column change: every step is guarded so a half-applied run repeats safely, and
the `users_email_unique` index is dropped *before* the column it refers to —
SQLite otherwise refuses the drop. I hit both of those while writing it.

## Verified

150 tests, including that no response carries an email and that the
`password_resets` table is gone. End to end on the real install: the migrated
account signed in, a fresh device created an account through the setup form,
and `dmp:user` updated it.

If you forget the password there is no email recovery — `php artisan dmp:user`
resets it from the console. That is now stated in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)