### PR TITLE
Give the voting screen a way out

### DIFF
--- a/resources/js/Views/Voting.vue
+++ b/resources/js/Views/Voting.vue
@@ -1,5 +1,16 @@
 <template>
     <div>
+        <!--
+            The only way off this screen. Voting is a full-bleed presentation
+            view with no navigation of its own, and the Pi runs Chromium in
+            kiosk mode, so there is no back button or address bar to fall back
+            on. Sits above every overlay, including the loading one, so a
+            screen that fails to load is still escapable.
+        -->
+        <button type="button" class="voting-exit" @click.prevent="exitVoting">
+            &larr; Exit voting
+        </button>
+
         <div class="loading-overlay" v-if="loading">
             <div class="p-12">{{ loadingMessage }}</div>
         </div>
@@ -277,6 +288,16 @@ export default {
         },
     },
     methods: {
+        exitVoting() {
+            this.disconnectSocket();
+            this.$router.push('/posters');
+        },
+        disconnectSocket() {
+            if (this.socket && typeof this.socket.disconnect === 'function') {
+                this.socket.disconnect();
+            }
+            this.socket = '';
+        },
         boot() {
             this.startSockets();
             this.getPosters();
@@ -476,10 +497,36 @@ export default {
     mounted() {
         this.boot();
     },
+    beforeUnmount() {
+        // Without this the socket outlives the screen: SPA navigation never
+        // unloads the page, so the server keeps listing you as a voter and the
+        // participant list fills with people who already left.
+        this.disconnectSocket();
+    },
 };
 </script>
 
 <style scoped lang="scss">
+.voting-exit {
+    position: fixed;
+    top: 16px;
+    left: 16px;
+    z-index: 600;
+    padding: 8px 14px;
+    border-radius: 4px;
+    font-size: 14px;
+    color: #ccc;
+    background-color: rgb(0 0 0 / 0.55);
+    transition:
+        color 0.2s ease,
+        background-color 0.2s ease;
+
+    &:hover {
+        color: #fff;
+        background-color: rgb(0 0 0 / 0.85);
+    }
+}
+
 .vote-container,
 .posters-container,
 .winner-container {

--- a/socketserver/server.js
+++ b/socketserver/server.js
@@ -17,9 +17,22 @@ const redis = new Redis({
     host: process.env.REDIS_HOST || '127.0.0.1',
     port: Number(process.env.REDIS_PORT || 6379),
     password: process.env.REDIS_PASSWORD || undefined,
+
+    // This process outlives any single Redis outage: the Pi may bring Redis up
+    // after this service, and Redis may be restarted under it. The default of
+    // 20 retries per request throws MaxRetriesPerRequestError from the command
+    // queue, which is not something the 'error' handler below can catch - it
+    // takes the whole process down, and with it voting and now-playing.
+    maxRetriesPerRequest: null,
+    retryStrategy: (attempt) => Math.min(attempt * 200, 5000),
 });
 
 redis.on('error', (err) => console.error('[dmp] redis error:', err.message));
+redis.on('ready', () => console.log('[dmp] redis connected'));
+
+process.on('unhandledRejection', (err) =>
+    console.error('[dmp] unhandled rejection:', err && err.message ? err.message : err)
+);
 
 const httpServer = createServer();
 const io = new Server(httpServer, {


### PR DESCRIPTION
The voting view had **no navigation of any kind** — no nav, no router links, not
a single anchor. The browser back button was the only way off it.

That's bad on a desktop and a dead end on the actual device: the Pi runs
Chromium with `--kiosk`, so there is no back button and no address bar.

## Fixed

- **"← Exit voting"**, fixed top-left, above every overlay in the view
  *including the loading one* — so a screen that fails to load is still
  escapable. Returns to the posters list, where the nav lives.
- **`beforeUnmount` disconnects the socket.** Nothing did before, and SPA
  navigation never unloads the page, so the server kept listing you as a
  present voter. The participant list filled up with people who had left.

## And one found while testing

The socket server **dies on a Redis outage**. ioredis throws
`MaxRetriesPerRequestError` from the command queue after 20 failed attempts —
which `redis.on('error')` cannot catch — and the process exits. I watched it
happen while verifying this fix.

The Pi may bring Redis up *after* this service, and Redis may be restarted under
it; neither should take voting and now-playing down with it. Retries are now
unlimited with backoff. It survived 25s with Redis refused, where it previously
died.

## Verified

In a browser: the control is visible and clickable both on the name prompt and
once signed into a session, and returns to `/posters`. Against the running
socket server: a voter who leaves is removed from the list
(`["probe","Tester"]` → `["probe"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)