### PR TITLE
Release 2.1.0

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,6 +1,6 @@
 {
     "latest": "2.1.0",
-    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
+    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account - including anyone who joins after voting has started. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
     "past_updates": [
         {
             "version": "2.0.0",

--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.0.0",
-    "changelog": "Laravel 13 refresh. Needs PHP 8.3+, so this cannot be installed from this screen - re-run install.sh on the device. The admin screens now ask for a login, and media server credentials are no longer sent to the browser.",
+    "latest": "2.1.0",
+    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
     "past_updates": [
+        {
+            "version": "2.0.0",
+            "changelog": "Laravel 13 refresh. Needs PHP 8.3+, so this cannot be installed from this screen - re-run install.sh on the device. The admin screens now ask for a login, and media server credentials are no longer sent to the browser."
+        },
         {
             "version": "1.7.153",
             "changelog": "Fixed Plex tv now playing"

--- a/public/version.json
+++ b/public/version.json
@@ -1,6 +1,6 @@
 {
     "latest": "2.1.0",
-    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account - including anyone who joins after voting has started. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
+    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Latecomers can join a vote already running, and a vote survives a phone locking or a tab closing. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
     "past_updates": [
         {
             "version": "2.0.0",

--- a/tests/Feature/UpdateApplicationTest.php
+++ b/tests/Feature/UpdateApplicationTest.php
@@ -75,7 +75,27 @@ class UpdateApplicationTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $version['latest']);
         $this->assertNotEmpty($version['changelog']);
         $this->assertNotEmpty($version['past_updates']);
-        $this->assertSame('1.7.153', $version['past_updates'][0]['version']);
+
+        foreach ($version['past_updates'] as $past) {
+            $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $past['version']);
+            $this->assertNotEmpty($past['changelog']);
+        }
+
+        // Assert the shape of a release rather than one release's number, which
+        // pinning the previous version turned into a test that had to be edited
+        // every time a version was published. What actually has to hold is that
+        // the newest entry in the history is the release before this one: a bump
+        // that forgot to archive its predecessor, or one that went backwards,
+        // both leave devices unable to see the update.
+        $this->assertGreaterThan(
+            0,
+            version_compare($version['latest'], $version['past_updates'][0]['version']),
+            'The published version must be newer than the top of the history.'
+        );
+
+        $archived = array_column($version['past_updates'], 'version');
+        $this->assertNotContains($version['latest'], $archived);
+        $this->assertSame($archived, array_unique($archived));
     }
 
     public function test_check_update_serves_the_published_version(): void


### PR DESCRIPTION
Publishes everything that has landed since 2.0.0.

## What ships

- **Voting from a QR code on the display** — open a session from the Voting
  screen, people scan and vote from their phones with no account (#13, #14, #15)
- **Title search with artwork lookup** (#8)
- **Username-and-password sign-in**, plus an Account tab for changing it
  (#11, #12)
- **Poster Sources rework**, sticky save, and a warning before leaving with
  unsaved changes (#9)
- Docs and packaging tidy-ups (#5, #6, #7, #10)

## This one installs from the About screen

2.0.0 could not: it needed a PHP upgrade, so it told operators to re-run
`install.sh`. Anything already on 2.0.0 is on PHP 8.3, so `update.sh` handles
2.1.0 in place — it runs the `username` migration, rebuilds the front end, and
restarts the socket server, which this release needs for voting.

Devices still on 1.x cannot update in place. The changelog says which is which.

## The version test no longer pins a release number

It asserted `past_updates[0]['version'] === '1.7.153'`, so publishing any version
broke it — a test that had to be edited every release is a test that gets edited
without being read.

It now asserts what actually has to hold:

- every history entry is a well-formed version with a changelog
- `latest` is newer than the top of the history
- `latest` does not also appear in the history, and the history has no duplicates

Verified it fails on a bump that forgets to archive its predecessor
(`Failed asserting that 0 is greater than 0`), and passes on the real file.

166 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)