### PR TITLE
Let people vote when they join after the vote has started

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ no Redis.
 6. Press **Start voting** on the **Live session** tab when everyone is in. That
    tab is the console for the running vote: who has joined, who has voted, and
    the count against each poster as it lands. Results appear when the timer
-   expires.
+   expires. **Join the vote** opens the voter page in a new tab so whoever is
+   running the session can take part too — keep the console tab open, since it
+   holds the controls.
+   Latecomers are welcome: anyone who scans and joins after voting has started
+   picks up the clock where it is and votes with whatever time is left.
 7. Thirty seconds after the results, the session closes itself and the QR code
    disappears. **Close session** ends it sooner.
 

--- a/resources/js/Views/Vote.vue
+++ b/resources/js/Views/Vote.vue
@@ -5,8 +5,8 @@
             <div v-if="!votingEnabled && !showResults" class="text-center">
                 <h1 class="text-white text-2xl font-bold mb-2">No vote running</h1>
                 <p class="text-gray-400">
-                    Nobody has opened a vote yet. Leave this page open — it will wake up on its
-                    own when one starts.
+                    Nobody has opened a vote yet. Leave this page open — it will wake up on its own
+                    when one starts.
                 </p>
             </div>
 
@@ -47,7 +47,11 @@
             <div v-else-if="votingStarted">
                 <div class="flex items-baseline justify-between mb-4">
                     <h1 class="text-white text-xl font-bold">
-                        {{ maxSelections === 1 ? 'Pick your favourite' : 'Pick up to ' + maxSelections }}
+                        {{
+                            maxSelections === 1
+                                ? 'Pick your favourite'
+                                : 'Pick up to ' + maxSelections
+                        }}
                     </h1>
                     <span class="text-white text-2xl font-bold">{{ timer }}</span>
                 </div>
@@ -80,10 +84,7 @@
                 <h1 class="text-white text-2xl font-bold mb-4">{{ resultMessage }}</h1>
                 <div class="poster-grid justify-center">
                     <div v-for="winner in winners" :key="winner.id" class="winner">
-                        <img
-                            :src="'/storage/posters/' + winner.file_name"
-                            :alt="winner.name"
-                        />
+                        <img :src="'/storage/posters/' + winner.file_name" :alt="winner.name" />
                         <span class="text-white text-sm">
                             {{ winner.votes }} vote<span v-if="winner.votes !== 1">s</span>
                         </span>
@@ -118,6 +119,8 @@ export default {
             voters: [],
             chosen: [],
             timer: 0,
+            countdown: null,
+            pendingStart: null,
             showResults: false,
             resultMessage: '',
             winners: [],
@@ -135,6 +138,17 @@ export default {
 
                 if (state.posters && state.posters.length) {
                     this.posters = state.posters;
+                }
+
+                // Someone who scans the code after voting has already started
+                // never receives start:voting, so take the running clock from
+                // the session broadcast instead. Without this their ballot
+                // renders with a timer of zero and every poster disabled: they
+                // can watch the vote but cannot join in.
+                if (state.votingStarted) {
+                    this.resumeCountdown(state.timer);
+                } else {
+                    this.stopCountdown();
                 }
 
                 if (!state.votingEnabled) {
@@ -155,6 +169,7 @@ export default {
             });
 
             this.socket.on('end:voting', (data) => {
+                this.stopCountdown();
                 this.votingStarted = false;
                 this.timer = 0;
                 this.winners = data.results.winner;
@@ -173,19 +188,46 @@ export default {
                 this.chosen = [];
             });
         },
+        /**
+         * Called when this client saw the vote start: show the full time, then
+         * begin counting after the five second "Get Ready" the other screens
+         * show.
+         */
         startCountdown(seconds) {
-            clearInterval(this.countdown);
-            // Matches the five second "Get Ready" the other screens show.
+            this.stopCountdown();
             this.timer = seconds;
-            setTimeout(() => {
-                this.countdown = setInterval(() => {
-                    if (this.timer > 0) {
-                        this.timer--;
-                    } else {
-                        clearInterval(this.countdown);
-                    }
-                }, 1000);
+            this.pendingStart = setTimeout(() => {
+                this.pendingStart = null;
+                this.tickFrom(this.timer);
             }, 5020);
+        },
+        /**
+         * Called when this client arrived to find a vote already running. There
+         * is no "Get Ready" to wait out - the seconds given are what is left.
+         */
+        resumeCountdown(seconds) {
+            if (this.countdown || this.pendingStart) {
+                return;
+            }
+
+            this.tickFrom(seconds);
+        },
+        tickFrom(seconds) {
+            this.stopCountdown();
+            this.timer = seconds;
+            this.countdown = setInterval(() => {
+                if (this.timer > 0) {
+                    this.timer--;
+                } else {
+                    this.stopCountdown();
+                }
+            }, 1000);
+        },
+        stopCountdown() {
+            clearInterval(this.countdown);
+            clearTimeout(this.pendingStart);
+            this.countdown = null;
+            this.pendingStart = null;
         },
         join() {
             if (!this.name.trim()) {
@@ -215,7 +257,7 @@ export default {
         this.connect();
     },
     beforeUnmount() {
-        clearInterval(this.countdown);
+        this.stopCountdown();
         if (this.socket) {
             this.socket.disconnect();
         }

--- a/resources/js/Views/Voting.vue
+++ b/resources/js/Views/Voting.vue
@@ -290,10 +290,22 @@
                                     >
                                         Reset votes
                                     </button>
+                                    <a
+                                        class="btn-plain btn-link"
+                                        :href="voteUrl"
+                                        target="_blank"
+                                        rel="noopener"
+                                    >
+                                        Join the vote
+                                    </a>
                                     <button type="button" class="btn-plain" @click="closeVoting()">
                                         Close session
                                     </button>
                                 </div>
+                                <p class="field-help">
+                                    Joining opens the voter page in a new tab, the same one the QR
+                                    code leads to. Keep this tab open to run the session.
+                                </p>
                             </div>
                         </template>
 
@@ -457,9 +469,18 @@ export default {
                 if (state.votingEnabled && state.maxSelections) {
                     this.maxSelections = state.maxSelections;
                 }
+
+                // Reopening this screen mid-vote means missing start:voting, so
+                // pick the running clock up from the broadcast rather than
+                // sitting on zero until the round ends.
+                if (state.votingStarted) {
+                    this.resumeTimer(state.timer);
+                }
             });
 
             this.socket.on('voting:disabled', () => {
+                this.stopReadyTimer();
+                this.stopTimer();
                 this.votingEnabled = false;
                 this.votingStarted = false;
                 this.runningPosters = [];
@@ -487,6 +508,8 @@ export default {
             });
 
             this.socket.on('end:voting', (data) => {
+                this.stopReadyTimer();
+                this.stopTimer();
                 this.resultStatus = data.results.status;
                 this.winners = data.results.winner;
                 this.votingStarted = data.votingStarted;
@@ -624,23 +647,46 @@ export default {
             return result;
         },
         startReadyTimer() {
-            clearInterval(this.readyInterval);
+            this.stopReadyTimer();
             this.readyInterval = setInterval(() => {
                 if (this.ready === 1) {
                     this.startTimer();
                 }
                 if (this.ready === 0) {
-                    clearInterval(this.readyInterval);
+                    this.stopReadyTimer();
                 } else {
                     this.ready--;
                 }
             }, 1000);
         },
-        startTimer() {
+        // Cleared handles are nulled rather than just cleared: a spent interval
+        // id stays truthy, and resumeTimer reads them to decide whether a clock
+        // is already running.
+        stopReadyTimer() {
+            clearInterval(this.readyInterval);
+            this.readyInterval = null;
+        },
+        stopTimer() {
             clearInterval(this.timerInterval);
+            this.timerInterval = null;
+        },
+        /**
+         * Picks up a round already in progress. The get-ready countdown has
+         * been and gone by then, so the seconds given are simply what is left.
+         */
+        resumeTimer(seconds) {
+            if (this.timerInterval || this.readyInterval) {
+                return;
+            }
+
+            this.timer = seconds;
+            this.startTimer();
+        },
+        startTimer() {
+            this.stopTimer();
             this.timerInterval = setInterval(() => {
                 if (this.timer === 0) {
-                    clearInterval(this.timerInterval);
+                    this.stopTimer();
                 } else {
                     this.timer--;
                 }
@@ -668,8 +714,8 @@ export default {
         // Without this the socket outlives the screen: SPA navigation never
         // unloads the page, so the server keeps listing you as a voter and the
         // participant list fills with people who already left.
-        clearInterval(this.readyInterval);
-        clearInterval(this.timerInterval);
+        this.stopReadyTimer();
+        this.stopTimer();
         this.disconnectSocket();
     },
 };
@@ -810,6 +856,18 @@ export default {
     margin-top: 6px;
     font-size: 14px;
     color: #9ca3af;
+}
+
+/*
+ * A real anchor rather than window.open: this screen owns the session, and a
+ * popup that gets blocked navigates in place instead, taking the controls with
+ * it. target=_blank on a link is never blocked, and it still offers the usual
+ * open-in-new-tab gestures.
+ */
+.btn-link {
+    display: inline-flex;
+    align-items: center;
+    text-decoration: none;
 }
 
 .btn-primary,


### PR DESCRIPTION
Reported: could not vote after starting the session.

## Reproduced

Open a session, press **Start voting**, *then* join from `/vote`. The ballot
renders — and every poster is disabled with the timer reading `0`:

```
{"text":"Pick up to 2 | 0 | 0 of 2 selected.","buttons":2,"disabled":[true,true]}
```

## Cause

`Vote.vue` only ever set its clock inside the `start:voting` handler — an event
a late arrival never receives. So `timer` stayed at its initial `0`, and
`:disabled="timer === 0"`, which exists to stop voting once time is up, locked
the grid from the outset.

Anyone who scans the QR after Start is in exactly this position, which is the
normal case for a code that stays on the display during the vote.

## Fix

The session broadcast already carries the running clock. Both screens now take
it from there when they arrive to find a vote in progress:

```
{"text":"Pick up to 2 | 20 | 0 of 2 selected.","buttons":2,"disabled":[false,false]}
```

The admin console had the same gap, less visibly — reopening `/voting` mid-vote
showed zero seconds left until the round ended.

Cleared interval handles are now nulled as well as cleared. A spent interval id
is still truthy, and the "is a clock already running" guard reads those handles,
so left as they were the resume would have worked once and then never again.

## Join the vote

Adds a button to the console so whoever is running the session can vote in it
too. It is a **link** with `target="_blank"`, not `window.open` — this screen
owns the session, and a blocked popup navigates in place instead, taking the
controls with it. I hit exactly that while testing.

## Verified

Session opened → **Start voting** → joined fresh from `/vote` → timer showed the
real remaining `20` with both posters enabled → cast a vote → console updated to
**1 voted**, `1 vote` on Matilda, clock live at 21s.

166 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)