### PR TITLE
Keep a vote when the voter's connection goes away

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ no Redis.
 The number of picks is enforced on the server as well as in the page, so a
 modified client cannot vote more times than the session allows.
 
+Votes survive the connection. Phones lock, tabs get closed, and a backgrounded
+tab has its websocket closed out from under it - a vote already cast stays in
+the count for the rest of the round. Each browser keeps a voter id in local
+storage, so coming back rejoins the same ballot: the page shows the picks
+already made, changing them replaces that vote, and reconnecting does not cast a
+second one.
+
 ## Display on/off schedule
 
 With `Use HDMI CEC Controls` enabled, DMP turns the TV on and off at the hours

--- a/resources/js/Views/Vote.vue
+++ b/resources/js/Views/Vote.vue
@@ -98,6 +98,32 @@
 <script>
 import { io } from 'socket.io-client';
 
+const VOTER_KEY = 'dmp.voterId';
+
+/**
+ * A name for this browser's ballot that outlives the connection.
+ *
+ * Votes used to be keyed by socket id, so a phone locking its screen - which
+ * closes the websocket - lost the vote, and coming back cast a second one.
+ * Stored rather than generated per load so a reload rejoins the same ballot.
+ */
+function voterId() {
+    try {
+        let id = window.localStorage.getItem(VOTER_KEY);
+
+        if (!id) {
+            id = 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+            window.localStorage.setItem(VOTER_KEY, id);
+        }
+
+        return id;
+    } catch (e) {
+        // Private browsing with storage denied: fall back to a per-load id.
+        // The vote still survives a background, just not a full reload.
+        return 'v-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+    }
+}
+
 /**
  * The screen people reach by scanning the QR code on the display.
  *
@@ -110,6 +136,7 @@ export default {
     data() {
         return {
             socket: null,
+            voterId: voterId(),
             name: '',
             joined: false,
             votingEnabled: false,
@@ -182,6 +209,13 @@ export default {
                           : 'Nobody voted.';
             });
 
+            // Sent when joining: whatever this voter already chose this round,
+            // so a reload or a woken phone shows their picks instead of an
+            // empty ballot they might cast again.
+            this.socket.on('your:votes', (data) => {
+                this.chosen = Array.isArray(data && data.posterIds) ? [...data.posterIds] : [];
+            });
+
             this.socket.on('voting:disabled', () => {
                 this.showResults = false;
                 this.joined = false;
@@ -233,7 +267,7 @@ export default {
             if (!this.name.trim()) {
                 return;
             }
-            this.socket.emit('new:user', { name: this.name.trim() });
+            this.socket.emit('new:user', { name: this.name.trim(), voterId: this.voterId });
             this.joined = true;
         },
         toggle(posterId) {

--- a/socketserver/server.js
+++ b/socketserver/server.js
@@ -61,10 +61,21 @@ let timer = 0;
 let lastWinner = {};
 let status = 'none';
 
-// socket id -> array of poster ids that voter has chosen. Holding the whole
+// voter id -> array of poster ids that voter has chosen. Holding the whole
 // selection per voter, rather than incrementing counters, means a reconnect or
 // a dropped message cannot leave the tally drifting away from reality.
+//
+// Keyed by voter id rather than socket id, and deliberately outliving the
+// socket: people vote on a phone and then lock it or switch apps, and a
+// backgrounded tab has its websocket closed. Dropping the selection with the
+// connection threw those votes away and could hand the round to the wrong
+// poster. The voter id is what makes that safe - it is a stable name for a
+// ballot, so someone coming back updates the vote they already cast instead of
+// casting a second one.
 const selections = new Map();
+
+// socket id -> voter id, so a disconnect knows whose ballot it belongs to.
+const socketVoters = new Map();
 
 // Results stay up for this long, then the session closes and the QR disappears.
 const RESULTS_VISIBLE_MS = Number(process.env.VOTING_RESULTS_MS || 30000);
@@ -169,9 +180,29 @@ io.on('connection', (socket) => {
     socket.emit('session', sessionState());
 
     socket.on('new:user', (data) => {
-        users.push({ id: socket.id, name: data.name, voted: false });
-        selections.set(socket.id, []);
+        const voterId = String((data && data.voterId) || socket.id);
+        socketVoters.set(socket.id, voterId);
 
+        const existing = users.find((user) => user.id === voterId);
+
+        if (existing) {
+            // Same person returning - a reload, or a phone waking up. Keep the
+            // ballot they already cast and put them back on the list.
+            existing.name = data.name || existing.name;
+            existing.connected = true;
+        } else {
+            users.push({ id: voterId, name: data.name, voted: false, connected: true });
+        }
+
+        if (!selections.has(voterId)) {
+            selections.set(voterId, []);
+        }
+
+        // Hand back whatever this voter has already chosen so a page that
+        // reloaded mid-round shows their picks rather than an empty ballot.
+        socket.emit('your:votes', { posterIds: selections.get(voterId) });
+
+        tally();
         io.emit('users', { users });
         socket.emit('status', {
             votingStarted,
@@ -241,20 +272,22 @@ io.on('connection', (socket) => {
     // A voter's complete selection, capped server side so a modified client
     // cannot vote more times than the session allows.
     socket.on('set:votes', (data) => {
-        if (!votingStarted) {
+        const voterId = socketVoters.get(socket.id);
+
+        if (!votingStarted || !voterId) {
             return;
         }
 
         const chosen = Array.isArray(data && data.posterIds) ? data.posterIds : [];
-        selections.set(socket.id, chosen.slice(0, maxSelections));
+        selections.set(voterId, chosen.slice(0, maxSelections));
 
         users = users.map((user) =>
-            user.id === socket.id ? { ...user, voted: selections.get(socket.id).length > 0 } : user
+            user.id === voterId ? { ...user, voted: selections.get(voterId).length > 0 } : user
         );
 
         tally();
 
-        io.emit('user:voted', { user_id: socket.id });
+        io.emit('user:voted', { user_id: voterId });
         io.emit('users', { users });
         broadcastSession();
     });
@@ -273,10 +306,34 @@ io.on('connection', (socket) => {
     });
 
     socket.on('disconnect', () => {
-        users = users.filter((user) => user.id !== socket.id);
-        selections.delete(socket.id);
-        tally();
+        const voterId = socketVoters.get(socket.id);
+        socketVoters.delete(socket.id);
 
+        if (!voterId) {
+            return;
+        }
+
+        // Their ballot stays in the tally for the rest of the round. Someone who
+        // put their phone away has still voted, and closing the tab is not a way
+        // to take a vote back.
+        const stillOpen = [...socketVoters.values()].includes(voterId);
+
+        if (!stillOpen) {
+            users = users.map((user) =>
+                user.id === voterId ? { ...user, connected: false } : user
+            );
+        }
+
+        // A voter who never cast anything leaves no trace: keeping them would
+        // pad the count with people who have gone.
+        const chosen = selections.get(voterId);
+
+        if (!stillOpen && (!chosen || chosen.length === 0)) {
+            users = users.filter((user) => user.id !== voterId);
+            selections.delete(voterId);
+        }
+
+        tally();
         io.emit('users', { users });
         broadcastSession();
     });


### PR DESCRIPTION
You asked me to check this. **The vote was lost**, and I could reproduce it
against the running server before touching anything:

```
after Ada votes:       A=1, B=0
after Ada disconnects: A=0, B=0
```

## Why

Votes were keyed by `socket.id`, and `disconnect` did `selections.delete(socket.id)`
followed by a re-tally. So a vote only counted while its tab stayed open.

That is the normal case on a phone rather than an edge case: locking the screen
or switching apps backgrounds the tab, and a backgrounded tab has its websocket
closed. The vote disappeared from the count with nothing shown to anyone, and
the round could be handed to the wrong poster.

## Why retaining the selection alone would have been worse

Socket ids are per connection, so reconnecting looked like a brand-new voter —
the third line of the original run shows a returning Ada being counted again.
Keeping ballots without a stable identity would have turned "close the tab and
come back" into a way to vote as many times as you like. The two halves had to
be fixed together.

Ballots are now keyed by a voter id the browser keeps in local storage, with the
server tracking which socket belongs to which voter.

```
after Ada votes:       A=1, B=0
after Ada disconnects: A=1, B=0     <- survives
after Ada rejoins:     A=1, B=0     <- not counted twice
after she votes again: A=1, B=0     <- replaces, does not add
```

Changing your mind after coming back still works — `Ada picks A: A=1, B=0` then
`Ada changes to B: A=0, B=1`.

## What a returning voter sees

The server hands back the picks already made, so the page shows them rather than
an empty ballot they might fill in again. Verified in a browser: voted for the
second poster, reloaded, rejoined, and got

```
"Pick up to 2 | 58 | 1 of 2 selected."   chosen: [false, true]   ticks: 1
```

Someone who joins and leaves *without* voting is still dropped, so the joined
count does not fill up with people who have gone.

## Also verified end to end

Voted, reloaded the page mid-round, and let the timer run out — the vote stood
and won: **"We have a winner! 1 vote"**. Under the old code that reload would
have zeroed the tally.

166 tests green, Pint clean, `node --check` clean.

## Note

Storage-denied private browsing falls back to a per-load id: the vote still
survives a background, just not a full reload. That seemed better than refusing
to let someone vote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)