### PR TITLE
Close the session properly, and keep the winner on screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,10 @@ no Redis.
    holds the controls.
    Latecomers are welcome: anyone who scans and joins after voting has started
    picks up the clock where it is and votes with whatever time is left.
-7. Thirty seconds after the results, the session closes itself and the QR code
-   disappears. **Close session** ends it sooner.
+7. Ten seconds after the results, the session closes itself and the QR code
+   disappears. **Close session** ends it sooner. The winner is not lost at that
+   point: it stays on the Setup tab, and on the voting page for anyone still
+   watching, labelled as the last session's winner until the next round starts.
 
 The number of picks is enforced on the server as well as in the page, so a
 modified client cannot vote more times than the session allows.

--- a/resources/js/Views/Vote.vue
+++ b/resources/js/Views/Vote.vue
@@ -3,10 +3,23 @@
         <div class="vote-inner">
             <!-- Nothing running -->
             <div v-if="!votingEnabled && !showResults" class="text-center">
-                <h1 class="text-white text-2xl font-bold mb-2">No vote running</h1>
+                <div v-if="lastWinners.length" class="mb-8">
+                    <h1 class="text-white text-2xl font-bold mb-4">Last session's winner</h1>
+                    <div class="poster-grid justify-center">
+                        <div v-for="winner in lastWinners" :key="winner.id" class="winner">
+                            <img :src="'/storage/posters/' + winner.file_name" :alt="winner.name" />
+                            <span class="text-white text-sm">
+                                {{ winner.votes }} vote<span v-if="winner.votes !== 1">s</span>
+                            </span>
+                        </div>
+                    </div>
+                </div>
+
+                <h1 v-else class="text-white text-2xl font-bold mb-2">No vote running</h1>
                 <p class="text-gray-400">
-                    Nobody has opened a vote yet. Leave this page open — it will wake up on its own
-                    when one starts.
+                    <span v-if="!lastWinners.length">Nobody has opened a vote yet. </span>
+                    Leave this page open — it will wake up on its own when
+                    {{ lastWinners.length ? 'the next vote' : 'one' }} starts.
                 </p>
             </div>
 
@@ -144,6 +157,7 @@ export default {
             maxSelections: 1,
             posters: [],
             voters: [],
+            lastResult: null,
             chosen: [],
             timer: 0,
             countdown: null,
@@ -152,6 +166,13 @@ export default {
             resultMessage: '',
             winners: [],
         };
+    },
+    computed: {
+        lastWinners() {
+            return this.lastResult && Array.isArray(this.lastResult.winner)
+                ? this.lastResult.winner
+                : [];
+        },
     },
     methods: {
         connect() {
@@ -162,6 +183,7 @@ export default {
                 this.votingStarted = state.votingStarted;
                 this.maxSelections = state.maxSelections;
                 this.voters = state.users || [];
+                this.lastResult = state.lastResult || null;
 
                 if (state.posters && state.posters.length) {
                     this.posters = state.posters;

--- a/resources/js/Views/Voting.vue
+++ b/resources/js/Views/Voting.vue
@@ -36,6 +36,25 @@
 
                     <!-- Setup: everything that has to be decided before people join. -->
                     <div v-show="tab === 'setup'" class="tab-panel">
+                        <div class="panel" v-if="lastWinners.length">
+                            <h3 class="panel-title">Last session's winner</h3>
+                            <div class="winner-container flex flex-wrap">
+                                <div class="winner-item past" v-for="winner in lastWinners">
+                                    <span class="votes"
+                                        >{{ winner.votes }} vote<span v-if="winner.votes !== 1"
+                                            >s</span
+                                        ></span
+                                    >
+                                    <img
+                                        :src="'/storage/posters/_tn_' + winner.file_name"
+                                        :alt="winner.name"
+                                        class="rounded-lg shadow-lg"
+                                    />
+                                </div>
+                            </div>
+                            <p class="field-help">{{ lastResultLabel }}</p>
+                        </div>
+
                         <div class="panel">
                             <h3 class="panel-title">Posters in the running</h3>
 
@@ -368,6 +387,7 @@ export default {
             users: [],
             posters: [],
             runningPosters: [],
+            lastResult: null,
             random: false,
             posterLimit: 3,
             chosenPosters: [],
@@ -432,6 +452,20 @@ export default {
             // announcing a winner that does not exist.
             return 'Nobody voted.';
         },
+        lastWinners() {
+            return this.lastResult && Array.isArray(this.lastResult.winner)
+                ? this.lastResult.winner
+                : [];
+        },
+        lastResultLabel() {
+            if (!this.lastResult) {
+                return '';
+            }
+
+            return this.lastResult.status === 'tie'
+                ? 'That round ended in a tie.'
+                : 'Stays here until the next round starts.';
+        },
         votedCount() {
             return this.users.filter((user) => user.voted).length;
         },
@@ -457,6 +491,7 @@ export default {
                 this.votingEnabled = state.votingEnabled;
                 this.votingStarted = state.votingStarted;
                 this.runningPosters = state.posters || [];
+                this.lastResult = state.lastResult || null;
 
                 // The session broadcast carries the whole voter list, so take
                 // it from here rather than accumulating user:voted events: a
@@ -1028,6 +1063,18 @@ export default {
     padding: 12px;
     background: #222;
     border-radius: 4px;
+}
+
+/* Smaller than a live result: setting up the next round is the job here. */
+.winner-item.past {
+    .votes {
+        font-size: 16px;
+        margin-bottom: 6px;
+    }
+
+    img {
+        max-width: 112px;
+    }
 }
 
 .winner-item {

--- a/socketserver/server.js
+++ b/socketserver/server.js
@@ -59,6 +59,12 @@ let disableTimerId = null;
 let timeLimit = 30;
 let timer = 0;
 let lastWinner = {};
+
+// The finished round, kept past the end of the session so the setup screen and
+// anyone still on the voting page can see who won last time. Cleared when a new
+// round starts, not when the session closes.
+let lastResult = null;
+
 let status = 'none';
 
 // voter id -> array of poster ids that voter has chosen. Holding the whole
@@ -78,7 +84,9 @@ const selections = new Map();
 const socketVoters = new Map();
 
 // Results stay up for this long, then the session closes and the QR disappears.
-const RESULTS_VISIBLE_MS = Number(process.env.VOTING_RESULTS_MS || 30000);
+// The winner is not lost at that point - it is kept as lastResult and shown as
+// the previous session's winner until a new round starts.
+const RESULTS_VISIBLE_MS = Number(process.env.VOTING_RESULTS_MS || 10000);
 
 function tally() {
     const counts = new Map();
@@ -102,6 +110,7 @@ function sessionState() {
         status,
         posters,
         lastWinner,
+        lastResult,
         users,
     };
 }
@@ -120,6 +129,13 @@ function closeSession() {
     votingStarted = false;
     posters = [];
     selections.clear();
+
+    // The session is over, so nobody is in it. Voters used to fall off this
+    // list as their sockets closed, but a ballot now outlives its connection -
+    // without clearing here, the finished session's voters lingered on the
+    // console and made a closed session look like it was still running.
+    users = [];
+
     timer = 0;
     timeLimit = 30;
     maxSelections = 1;
@@ -149,6 +165,7 @@ function calcWinner() {
 
     votingStarted = false;
     status = 'done';
+    lastResult = { status: winningStatus, winner };
 
     io.emit('end:voting', {
         votingStarted: false,
@@ -237,6 +254,12 @@ io.on('connection', (socket) => {
     socket.on('disable:voting', () => closeSession());
 
     socket.on('start:voting', (data) => {
+        // Starting again inside the results window would otherwise leave the
+        // previous round's close timer pending, and it would shut the new
+        // session down partway through.
+        clearTimeout(disableTimerId);
+        disableTimerId = null;
+
         if (data && data.posters) {
             posters = data.posters.map((poster) => ({ ...poster, votes: 0 }));
         }
@@ -244,6 +267,7 @@ io.on('connection', (socket) => {
             maxSelections = Math.max(1, Number(data.maxSelections) || 1);
         }
 
+        lastResult = null;
         timeLimit = Number((data && data.timeLimit) || timeLimit) || 30;
         timer = timeLimit;
         votingEnabled = true;


### PR DESCRIPTION
## The close timer was firing on time

I traced a full round against the running server before changing anything:

```
11.6s  >> end:voting
41.6s  >> voting:disabled
```

Exactly thirty seconds, as designed. What stayed behind was the **voter list**.

`closeSession()` cleared the posters and the selections but not `users`. That
never mattered while voters fell off the list as their sockets closed — but
[#18](https://github.com/devMikeFrancis/digital-movie-poster/pull/18) made a
ballot outlive its connection, so they stopped falling off:

```
after close, users: [{"id":"ada-ghost","name":"Ada","voted":true,"connected":false}]
```

A finished session kept its voters on the console, which is what "not closing"
looks like on screen. My regression, from the fix two PRs ago.

## Ten seconds

`RESULTS_VISIBLE_MS` now defaults to 10000. Verified end to end:

```
11.6s  >> end:voting
21.6s  >> voting:disabled  (closed 10.0s after results)
24.0s  after close -> enabled=false users=[]
24.0s  after close -> lastResult=["B=1"]
```

## The winner stays up

It is no longer thrown away when the session closes — it is kept as
`lastResult` and shown as **Last session's winner** until a new round starts:

- on the **Setup** tab, smaller than a live result since setting up the next
  round is the job on that screen
- on **/vote** for anyone still watching, which also gives the page people are
  left on something better than "no vote running" the moment a vote they just
  took part in ends

## One more found while in there

Starting a round now clears any pending close from the previous one. A second
round begun inside the results window would otherwise have been shut down
partway through by the timer left over from the first.

## Verified in a browser

Ran a full round, voted, and let it close: Setup shows "Last session's winner"
with Matilda at 1 vote and "Stays here until the next round starts"; the Live
tab correctly falls back to "No session open"; `/vote` shows the winner with
"Leave this page open — it will wake up on its own when the next vote starts."

166 tests green, Pint clean, `node --check` clean.

## Note

The socket server is a long-lived process — this needs a restart to take effect.
`update.sh` already does that via pm2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)