### PR TITLE
End voting early, gate the controls, and let the console close

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,12 @@ no Redis.
    holds the controls.
    Latecomers are welcome: anyone who scans and joins after voting has started
    picks up the clock where it is and votes with whatever time is left.
-7. Ten seconds after the results, the session closes itself and the QR code
-   disappears. **Close session** ends it sooner. The winner is not lost at that
+7. **Close voting** ends the round early and shows the result there and then,
+   rather than waiting out the clock.
+8. Ten seconds after the results, the session closes itself and the QR code
+   disappears. **Close session** ends it sooner. A session that is opened for
+   joining and never started closes on its own after ten minutes, so the QR code
+   is not left stranded on the display. The winner is not lost at that
    point: it stays on the Setup tab, and on the voting page for anyone still
    watching, labelled as the last session's winner until the next round starts.
 

--- a/resources/js/Views/Voting.vue
+++ b/resources/js/Views/Voting.vue
@@ -202,7 +202,15 @@
                             </button>
                         </div>
 
-                        <template v-else>
+                        <!--
+                            Bound to the session itself, not to "not the empty
+                            state": pairing this with the empty state's v-else
+                            meant that once results were showing it rendered
+                            again even though the session had closed, leaving a
+                            console full of live controls under a No session
+                            badge.
+                        -->
+                        <template v-if="votingEnabled">
                             <div class="panel">
                                 <div class="stats">
                                     <div class="stat">
@@ -294,9 +302,17 @@
 
                                 <div class="flex flex-wrap gap-2">
                                     <button
+                                        v-if="votingStarted"
                                         type="button"
                                         class="btn-primary"
-                                        :disabled="votingStarted"
+                                        @click="endVotingNow()"
+                                    >
+                                        Close voting
+                                    </button>
+                                    <button
+                                        v-else
+                                        type="button"
+                                        class="btn-primary"
                                         @click="startVoting()"
                                     >
                                         Start voting
@@ -304,7 +320,7 @@
                                     <button
                                         type="button"
                                         class="btn-plain"
-                                        :disabled="votingStarted"
+                                        :disabled="votingStarted || !votedCount"
                                         @click="resetVoting()"
                                     >
                                         Reset votes
@@ -317,12 +333,20 @@
                                     >
                                         Join the vote
                                     </a>
-                                    <button type="button" class="btn-plain" @click="closeVoting()">
+                                    <button
+                                        v-if="votingEnabled"
+                                        type="button"
+                                        class="btn-plain"
+                                        @click="closeVoting()"
+                                    >
                                         Close session
                                     </button>
                                 </div>
                                 <p class="field-help">
-                                    Joining opens the voter page in a new tab, the same one the QR
+                                    <span v-if="votingStarted"
+                                        >Closing voting counts what is in and shows the result
+                                        without waiting for the clock. </span
+                                    >Joining opens the voter page in a new tab, the same one the QR
                                     code leads to. Keep this tab open to run the session.
                                 </p>
                             </div>
@@ -605,6 +629,15 @@ export default {
             });
 
             this.tab = 'live';
+        },
+        /**
+         * Ends the round now rather than waiting out the clock. The result is
+         * whatever has been cast, and the session closes on the usual delay
+         * afterwards, so this is the early exit rather than a separate path.
+         */
+        endVotingNow() {
+            this.startMessages = [];
+            this.socket.emit('end:voting:now', {});
         },
         closeVoting() {
             this.startMessages = [];

--- a/socketserver/server.js
+++ b/socketserver/server.js
@@ -56,6 +56,7 @@ let maxSelections = 1;
 
 let timerId = null;
 let disableTimerId = null;
+let idleTimerId = null;
 let timeLimit = 30;
 let timer = 0;
 let lastWinner = {};
@@ -88,6 +89,12 @@ const socketVoters = new Map();
 // the previous session's winner until a new round starts.
 const RESULTS_VISIBLE_MS = Number(process.env.VOTING_RESULTS_MS || 10000);
 
+// A session that is opened for joining and then never started used to stay open
+// for ever, leaving the QR code stranded on the display. Generous on purpose:
+// an admin who opens the vote early and waits for the room to fill should not
+// have it closed out from under them.
+const IDLE_SESSION_MS = Number(process.env.VOTING_IDLE_MS || 600000);
+
 function tally() {
     const counts = new Map();
 
@@ -119,9 +126,15 @@ function broadcastSession() {
     io.emit('session', sessionState());
 }
 
-function closeSession() {
+function clearPendingCloses() {
     clearTimeout(disableTimerId);
+    clearTimeout(idleTimerId);
     disableTimerId = null;
+    idleTimerId = null;
+}
+
+function closeSession() {
+    clearPendingCloses();
     clearInterval(timerId);
     timerId = null;
 
@@ -178,7 +191,7 @@ function calcWinner() {
 
     // Give everyone time to see the result, then close the session so the
     // slideshow stops advertising a vote that has finished.
-    clearTimeout(disableTimerId);
+    clearPendingCloses();
     disableTimerId = setTimeout(closeSession, RESULTS_VISIBLE_MS);
 }
 
@@ -235,8 +248,11 @@ io.on('connection', (socket) => {
 
     // The admin opens a session: voters can join and the slideshow shows the QR.
     socket.on('enable:voting', (data) => {
-        clearTimeout(disableTimerId);
-        disableTimerId = null;
+        clearPendingCloses();
+
+        // Nothing has been started yet, so put a ceiling on how long this can
+        // sit there advertising itself.
+        idleTimerId = setTimeout(closeSession, IDLE_SESSION_MS);
 
         posters = (data.posters || []).map((poster) => ({ ...poster, votes: 0 }));
         maxSelections = Math.max(1, Number(data.maxSelections) || 1);
@@ -253,12 +269,27 @@ io.on('connection', (socket) => {
 
     socket.on('disable:voting', () => closeSession());
 
+    // Ends the round now rather than waiting for the clock: counts what is in,
+    // publishes the result, and lets the usual results window close the session.
+    socket.on('end:voting:now', () => {
+        if (!votingStarted) {
+            return;
+        }
+
+        clearInterval(timerId);
+        timerId = null;
+        timer = 0;
+
+        calcWinner();
+        console.log('[dmp] voting ended early by the admin');
+    });
+
     socket.on('start:voting', (data) => {
         // Starting again inside the results window would otherwise leave the
         // previous round's close timer pending, and it would shut the new
-        // session down partway through.
-        clearTimeout(disableTimerId);
-        disableTimerId = null;
+        // session down partway through. The idle timer goes too - the session
+        // is plainly not idle any more.
+        clearPendingCloses();
 
         if (data && data.posters) {
             posters = data.posters.map((poster) => ({ ...poster, votes: 0 }));


### PR DESCRIPTION
## The session was closing — the console was not

You were right that something was not closing, and it was not the timer. I
checked the server first and it closes on schedule. What stayed on screen was
the admin console.

Its live controls were bound to the empty state's `v-else`, and that empty state
is `!votingEnabled && !showResults`. So once results were showing, the else
branch rendered the whole console **again** even though the session had closed:

```
badge=No session   visible actions=["Start voting","Reset votes","Join the vote"]
```

Start voting under a "No session" badge is exactly what a session that will not
close looks like from the admin screen. The console is now bound to the session
itself rather than to "not the empty state". After close:

```
badge=No session   visible actions=[]
```

That regression was mine, from the empty-state tidy-up two PRs back.

## A second gap was real

A session opened for joining and never started had **no close timer at all**:

```
 0.3s  opening a session and never starting it
20.3s  20s later -> enabled=true status=open
```

It stayed open for ever with the QR stranded on the display. Those now close
after ten minutes — generous on purpose, so an admin who opens the vote early
and waits for the room to fill does not have it closed out from under them.
Starting a round cancels it. Verified with a short window:

```
 4.0s  >> voting:disabled (idle timeout)
14.5s  8s after start -> enabled=true started=true  (idle close did NOT fire)
```

## Close voting

**Start voting** becomes **Close voting** while a round is running. It counts
what is in and publishes the result rather than waiting out the clock, and the
usual results window closes the session afterwards — the early exit, not a
separate path. A 120s round ended on command:

```
 6.8s  vote cast; timer still at 120
 6.8s  admin closes voting early
 6.8s  >> end:voting  winner=["A=1"]
16.8s  >> voting:disabled  (10.0s after results)
19.2s  enabled=false users=[] lastWinner=["A=1"]
```

## The other two

- **Reset votes** is disabled until a vote has actually been cast
- **Close session** only appears while a session is open

Button states through a full cycle:

```
open, not started -> ["Start voting","Reset votes [disabled]","Close session","Join the vote"]
started           -> ["Close voting","Reset votes [disabled]","Close session"]
after early close -> ["Start voting","Reset votes","Close session"]
after auto-close  -> []
```

166 tests green, Pint clean, `node --check` clean.

## Note

The socket server needs a restart to pick this up; `update.sh` does that via
pm2. A browser tab left open also keeps its old bundle — worth a reload when
checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)