### PR TITLE
Release 2.1.1

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.1.0",
-    "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Latecomers can join a vote already running, and a vote survives a phone locking or a tab closing. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device.",
+    "latest": "2.1.1",
+    "changelog": "The display now gives the whole screen to a vote while one is running - Vote Now, a large QR code and the countdown - and shows the winner before returning to the slideshow. Voting can be ended early, a session left open closes itself, and the admin console no longer lingers after one ends. New display options: fill the screen with the poster (scaled to fit, never cropped), hide the Coming Soon / Now Playing text, and show your theater name above or below the poster. The rating display limits no longer show blank when no limit is set, and the details around a poster now change with it instead of ahead of it.",
     "past_updates": [
+        {
+            "version": "2.1.0",
+            "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Latecomers can join a vote already running, and a vote survives a phone locking or a tab closing. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device."
+        },
         {
             "version": "2.0.0",
             "changelog": "Laravel 13 refresh. Needs PHP 8.3+, so this cannot be installed from this screen - re-run install.sh on the device. The admin screens now ask for a login, and media server credentials are no longer sent to the browser."


### PR DESCRIPTION
Publishes what has landed since 2.1.0.

## What ships

- **The display gives its whole screen to a running vote** —
  [#21](https://github.com/devMikeFrancis/digital-movie-poster/pull/21). Vote Now,
  a large QR code and the countdown, the winner on the same screen, then back to
  the slideshow.
- **Voting controls** —
  [#20](https://github.com/devMikeFrancis/digital-movie-poster/pull/20). End a
  round early, gated Reset votes and Close session, a console that actually goes
  away when the session ends, and an idle session that closes itself.
- **Four display options** —
  [#22](https://github.com/devMikeFrancis/digital-movie-poster/pull/22). Fill the
  screen with the poster (scaled to fit, never cropped), hide the Coming Soon /
  Now Playing text, show your theater name above or below the poster, and the
  rating limits no longer render blank. The details around a poster now change
  with it rather than ahead of it.

## Installing

From the About screen, as 2.1.0 was. `update.sh` runs the migration behind the
new display options and restarts the socket server — this release needs that
restart, since most of the voting behaviour lives in `server.js`.

Devices still on 1.x cannot update in place and need `install.sh` re-run.

## One thing worth your call

**This is numbered as a patch, as you asked, but it carries features** — a new
full-screen voting display and four display options — which conventionally reads
as 2.2.0. Nothing breaks either way; devices compare dotted versions and will
offer the update regardless. Say the word and it is a one-line change.

170 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)