### PR TITLE
Stop the header and footer covering a filled poster, and make the shading an option

### DIFF
--- a/app/Http/Requests/SettingsRequest.php
+++ b/app/Http/Requests/SettingsRequest.php
@@ -54,6 +54,7 @@ class SettingsRequest extends FormRequest
             'use_global_prologos_if_no_poster_prologos' => 'required|boolean',
             'transition_type' => 'required|string',
             'poster_fill_screen' => 'required|boolean',
+            'poster_fill_scrim' => 'required|in:none,subtle,standard,strong',
             'show_header_text' => 'required|boolean',
             'show_theater_name' => 'required|boolean',
             'theater_name' => 'nullable|string|max:120',
@@ -116,6 +117,7 @@ class SettingsRequest extends FormRequest
             // admin UI always sends it, but a payload that leaves it out should
             // land on the sensible option rather than fail validation.
             'theater_name_position' => $this->input('theater_name_position') ?: 'bottom',
+            'poster_fill_scrim' => $this->input('poster_fill_scrim') ?: 'standard',
             'jellyfin_service' => $this->boolean('jellyfin_service'),
             'show_header_border' => $this->boolean('show_header_border'),
             'validate_movie_titles' => $this->boolean('validate_movie_titles'),

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -40,6 +40,7 @@ class Setting extends Model
         'use_global_prologos_if_no_poster_prologos',
         'transition_type',
         'poster_fill_screen',
+        'poster_fill_scrim',
         'show_header_text',
         'show_theater_name',
         'theater_name',
@@ -92,6 +93,15 @@ class Setting extends Model
     protected $casts = [
         'plex_movie_sections' => 'array',
         'plex_tv_sections' => 'array',
+
+        // Cast rather than given an accessor apiece like the older flags: an
+        // integer here reaches the admin UI as 1, and a checkbox bound with
+        // v-model only ticks for a real true - so the box showed empty while
+        // the option was on, and saving that form turned it off.
+        'poster_fill_screen' => 'boolean',
+        'show_header_text' => 'boolean',
+        'show_theater_name' => 'boolean',
+
         'plex_token' => EncryptedCredential::class,
         'jellyfin_token' => EncryptedCredential::class,
         'kodi_username' => EncryptedCredential::class,

--- a/database/migrations/2026_08_19_000002_add_poster_fill_scrim_to_settings_table.php
+++ b/database/migrations/2026_08_19_000002_add_poster_fill_scrim_to_settings_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            // How heavily to shade the top and bottom of a filled poster so the
+            // header and footer text stays readable over the artwork.
+            $table->string('poster_fill_scrim', 20)->default('standard');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('poster_fill_scrim');
+        });
+    }
+};

--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -362,11 +362,40 @@ export default {
         background-position: center;
     }
 
+    /*
+     * The chrome floats over the artwork rather than sitting on it. With its
+     * configured background colour it was an opaque bar at each end, hiding
+     * about a third of a full-height poster - the artwork was never cropped,
+     * it was covered up. A gradient behind the two ends keeps the text
+     * readable over whatever happens to be there.
+     */
     .top-header,
     .poster-footer,
     .theater-name {
         position: relative;
         z-index: 2;
+        background-color: transparent !important;
+    }
+
+    &::before,
+    &::after {
+        content: '';
+        position: fixed;
+        left: 0;
+        right: 0;
+        height: 30vh;
+        z-index: 1;
+        pointer-events: none;
+    }
+
+    &::before {
+        top: 0;
+        background: linear-gradient(to bottom, rgb(0 0 0 / 0.85), rgb(0 0 0 / 0));
+    }
+
+    &::after {
+        bottom: 0;
+        background: linear-gradient(to top, rgb(0 0 0 / 0.85), rgb(0 0 0 / 0));
     }
 }
 

--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -9,7 +9,7 @@
             <div
                 id="recent-added-container"
                 class="poster-container"
-                :class="{ 'fill-screen': fillScreen }"
+                :class="[{ 'fill-screen': fillScreen }, scrimClass]"
                 @click.prevent="gotoPosters()"
                 v-if="!isPlaying"
             >
@@ -62,7 +62,7 @@
                 <div
                     id="now-playing-container"
                     class="poster-container"
-                    :class="{ 'fill-screen': fillScreen }"
+                    :class="[{ 'fill-screen': fillScreen }, scrimClass]"
                     v-if="isPlaying"
                     @click.prevent="gotoPosters()"
                 >
@@ -157,6 +157,11 @@ export default {
         ...mapGetters(usePostersStore, ['mediaPosters']),
         fillScreen() {
             return !!this.settings.poster_fill_screen;
+        },
+        scrimClass() {
+            const choice = this.settings.poster_fill_scrim || 'standard';
+
+            return this.fillScreen ? 'scrim-' + choice : '';
         },
         theaterNameOn() {
             if (!this.settings.show_theater_name || !this.settings.theater_name) {
@@ -383,20 +388,50 @@ export default {
         position: fixed;
         left: 0;
         right: 0;
-        height: 30vh;
+        height: var(--scrim-height, 30vh);
         z-index: 1;
         pointer-events: none;
     }
 
     &::before {
         top: 0;
-        background: linear-gradient(to bottom, rgb(0 0 0 / 0.85), rgb(0 0 0 / 0));
+        background: linear-gradient(
+            to bottom,
+            rgb(0 0 0 / var(--scrim-alpha, 0.85)),
+            rgb(0 0 0 / 0)
+        );
     }
 
     &::after {
         bottom: 0;
-        background: linear-gradient(to top, rgb(0 0 0 / 0.85), rgb(0 0 0 / 0));
+        background: linear-gradient(to top, rgb(0 0 0 / var(--scrim-alpha, 0.85)), rgb(0 0 0 / 0));
     }
+}
+
+/*
+ * How heavily the ends are shaded. A dark poster needs none of this; a bright
+ * one needs quite a lot before white text on it is readable, and that is a
+ * judgement about a particular room and screen rather than something worth
+ * guessing at.
+ */
+.scrim-none::before,
+.scrim-none::after {
+    display: none;
+}
+
+.scrim-subtle {
+    --scrim-height: 20vh;
+    --scrim-alpha: 0.6;
+}
+
+.scrim-standard {
+    --scrim-height: 30vh;
+    --scrim-alpha: 0.85;
+}
+
+.scrim-strong {
+    --scrim-height: 42vh;
+    --scrim-alpha: 0.95;
 }
 
 .poster {

--- a/resources/js/Views/Settings.vue
+++ b/resources/js/Views/Settings.vue
@@ -166,9 +166,34 @@
                                     </label>
                                     <div id="fillScreenHelp" class="text-gray-400 text-sm">
                                         The poster takes the whole display instead of sitting in a
-                                        box between the header and footer, which sit over it
+                                        box between the header and footer, which float over it
                                         instead. It is scaled to fit rather than cropped, so it
                                         keeps its shape and nothing is cut off.
+                                    </div>
+
+                                    <div v-if="settings.poster_fill_screen" class="mt-3">
+                                        <label
+                                            for="fill-scrim"
+                                            class="text-gray-300 block mb-2 font-bold"
+                                        >
+                                            Shading behind the header and footer
+                                        </label>
+                                        <select
+                                            class="text-black"
+                                            id="fill-scrim"
+                                            aria-describedby="fillScrimHelp"
+                                            v-model="settings.poster_fill_scrim"
+                                        >
+                                            <option value="none">None</option>
+                                            <option value="subtle">Subtle</option>
+                                            <option value="standard">Standard</option>
+                                            <option value="strong">Strong</option>
+                                        </select>
+                                        <div id="fillScrimHelp" class="text-gray-400 text-sm mt-1">
+                                            Darkens the top and bottom of the screen so the header
+                                            and footer text stays readable over the artwork. A dark
+                                            poster needs none of it; a bright one needs quite a lot.
+                                        </div>
                                     </div>
                                 </div>
 
@@ -1487,6 +1512,7 @@ export default {
             accountErrors: [],
             settings: {
                 poster_fill_screen: false,
+                poster_fill_scrim: 'standard',
                 show_header_text: true,
                 show_theater_name: false,
                 theater_name: '',
@@ -1713,6 +1739,10 @@ export default {
 
             if (!settings.theater_name_position) {
                 settings.theater_name_position = 'bottom';
+            }
+
+            if (!settings.poster_fill_scrim) {
+                settings.poster_fill_scrim = 'standard';
             }
 
             return settings;

--- a/tests/Feature/SettingsApiTest.php
+++ b/tests/Feature/SettingsApiTest.php
@@ -51,6 +51,53 @@ class SettingsApiTest extends TestCase
         $this->assertSame('top', $settings->theater_name_position);
     }
 
+    public function test_the_fill_scrim_defaults_to_standard_and_accepts_the_named_strengths(): void
+    {
+        $this->assertSame('standard', Setting::first()->poster_fill_scrim);
+
+        $this->putJson('/api/settings', $this->validPayload([
+            'poster_fill_scrim' => 'none',
+        ]))->assertOk();
+
+        $this->assertSame('none', Setting::first()->poster_fill_scrim);
+    }
+
+    public function test_the_fill_scrim_rejects_anything_else(): void
+    {
+        $this->putJson('/api/settings', $this->validPayload([
+            'poster_fill_scrim' => 'very',
+        ]))->assertStatus(422)->assertJsonValidationErrors('poster_fill_scrim');
+    }
+
+    public function test_a_payload_without_a_fill_scrim_falls_back_to_standard(): void
+    {
+        $payload = $this->validPayload();
+        unset($payload['poster_fill_scrim']);
+
+        $this->putJson('/api/settings', $payload)->assertOk();
+
+        $this->assertSame('standard', Setting::first()->poster_fill_scrim);
+    }
+
+    public function test_the_new_flags_are_real_booleans_for_the_admin_form(): void
+    {
+        // A checkbox bound with v-model only ticks for a real true. Handing the
+        // form a 1 left the box empty while the option was on, and saving that
+        // form turned the option off.
+        $this->putJson('/api/settings', $this->validPayload([
+            'poster_fill_screen' => true,
+            'show_header_text' => true,
+            'show_theater_name' => true,
+        ]))->assertOk();
+
+        $payload = $this->getJson('/api/settings/full')->assertOk()->json();
+
+        foreach (['poster_fill_screen', 'show_header_text', 'show_theater_name'] as $flag) {
+            $this->assertTrue($payload[$flag], $flag.' should come back as a real boolean');
+            $this->assertIsBool($payload[$flag], $flag.' should come back as a real boolean');
+        }
+    }
+
     public function test_the_theater_name_position_only_accepts_top_or_bottom(): void
     {
         $this->putJson('/api/settings', $this->validPayload([
@@ -78,6 +125,7 @@ class SettingsApiTest extends TestCase
             ->assertOk()
             ->assertJsonStructure([
                 'poster_fill_screen',
+                'poster_fill_scrim',
                 'show_header_text',
                 'show_theater_name',
                 'theater_name',


### PR DESCRIPTION
Reported: the poster is cut off at the top and bottom in fill mode.

## It was not being cropped — it was being covered

Measured on the running display. The artwork draws at the full height of the
screen, uncropped, exactly as intended. But the header and footer kept their
configured background colour and sat on top of it:

```
artworkDrawn    480 x 720   (full screen height, ratio kept)
hiddenTopPx     101         header
hiddenBottomPx  143         footer 101 + theatre name 43
```

About a third of a 720 tall poster behind solid black bars, which reads exactly
like the ends being cut off. My mistake in
[#22](https://github.com/devMikeFrancis/digital-movie-poster/pull/22): I checked
that `background-size` was not cropping and stopped there, without checking what
was painted over the result.

In fill mode the chrome now floats over the artwork — transparent backgrounds,
with a gradient at each end so the text stays readable over whatever is behind
it:

```
artwork y=0 h=720 bottom=720   fillsFullHeight: true
opaqueChromeOverArt: []
```

Outside fill mode nothing changes; there the header and footer are bars by
design, and they still are (no scrim, backgrounds still `rgb(0, 0, 0)`, poster
boxed between them at y=101 h=476).

## The shading is a setting

How heavy it should be is a judgement about a particular room and screen — a
dark poster needs none of it, a bright one needs quite a lot before white text
over it is readable. **None / Subtle / Standard / Strong**, defaulting to
Standard, which is the 30vh at 85% this branch already had. It only appears when
fill mode is on. Each variant verified to paint differently:

```
none      display: none
subtle    144px   rgba(0,0,0,0.6)
standard  216px   rgba(0,0,0,0.85)     <- default
strong    302px   rgba(0,0,0,0.95)
```

## A worse bug found while testing that

The three new flags reached the admin form as `1` rather than `true`, and a
checkbox bound with `v-model` only ticks for a real `true`:

```
random_order        api true (boolean)  checkbox true    <- existing flag, fine
poster_fill_screen  api 1    (number)   checkbox false   <- mine
show_header_text    api 1    (number)   checkbox false
show_theater_name   api 1    (number)   checkbox false
```

So the box sat empty while the option was on — and **saving that form would have
written `false` and quietly turned the option off**. The older flags avoid this
with an accessor apiece; a cast does the same job. There is now a test asserting
the payload really is boolean, so this cannot come back silently.

## Note

This is a fix to what shipped in 2.1.1, so it wants a 2.1.2 to reach devices.

174 tests green (4 new), Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)