### PR TITLE
Release 2.1.2

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.1.1",
-    "changelog": "The display now gives the whole screen to a vote while one is running - Vote Now, a large QR code and the countdown - and shows the winner before returning to the slideshow. Voting can be ended early, a session left open closes itself, and the admin console no longer lingers after one ends. New display options: fill the screen with the poster (scaled to fit, never cropped), hide the Coming Soon / Now Playing text, and show your theater name above or below the poster. The rating display limits no longer show blank when no limit is set, and the details around a poster now change with it instead of ahead of it.",
+    "latest": "2.1.2",
+    "changelog": "Fixes a poster that looked cut off at the top and bottom when filling the screen: the artwork was full height all along, but the header and footer were sitting on top of it. They now float over the poster, with shading behind them so the text stays readable - how heavy that shading is has its own setting. Also fixes the new display options showing as switched off in Settings when they were on, which could switch them off for real the next time you saved.",
     "past_updates": [
+        {
+            "version": "2.1.1",
+            "changelog": "The display now gives the whole screen to a vote while one is running - Vote Now, a large QR code and the countdown - and shows the winner before returning to the slideshow. Voting can be ended early, a session left open closes itself, and the admin console no longer lingers after one ends. New display options: fill the screen with the poster (scaled to fit, never cropped), hide the Coming Soon / Now Playing text, and show your theater name above or below the poster. The rating display limits no longer show blank when no limit is set, and the details around a poster now change with it instead of ahead of it."
+        },
         {
             "version": "2.1.0",
             "changelog": "Movie voting from a QR code: open a session from the Voting screen, a code appears on the display, and people vote from their phones without an account. Latecomers can join a vote already running, and a vote survives a phone locking or a tab closing. Also adds title search with artwork lookup, username-and-password sign-in with an Account tab for changing it, and a clearer Poster Sources tab that warns before you leave with unsaved changes. Updating from 2.0.0 works from this screen; from 1.x, re-run install.sh on the device."


### PR DESCRIPTION
Publishes the fill-mode fixes from
[#24](https://github.com/devMikeFrancis/digital-movie-poster/pull/24).

## What ships

- **A filled poster is no longer covered at the ends.** The artwork was full
  height all along; the header and footer were sitting on top of it, hiding
  about a third of it. They now float over the poster.
- **Shading behind the header and footer is a setting** — None, Subtle,
  Standard or Strong, defaulting to Standard.
- **The new display options no longer show as switched off when they are on.**
  They reached the admin form as `1` rather than `true`, so their checkboxes sat
  empty — and saving that form wrote `false` and turned the option off for real.

That last one is the reason to take this promptly: anyone who set fill screen,
hid the header text or added a theater name in 2.1.1 will lose those settings
the next time they save anything on that page.

## Installing

From the About screen. `update.sh` runs the migration behind the new shading
setting and restarts the socket server.

174 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)