### PR TITLE
Add cross-fade and cut to the transition types

### DIFF
--- a/app/Http/Requests/SettingsRequest.php
+++ b/app/Http/Requests/SettingsRequest.php
@@ -52,7 +52,7 @@ class SettingsRequest extends FormRequest
             'play_theme_music' => 'required|boolean',
             'use_global_prologos' => 'required|boolean',
             'use_global_prologos_if_no_poster_prologos' => 'required|boolean',
-            'transition_type' => 'required|string',
+            'transition_type' => 'required|in:fade,crossfade,vertical,cut',
             'poster_fill_screen' => 'required|boolean',
             'poster_fill_scrim' => 'required|in:none,subtle,standard,strong',
             'show_header_text' => 'required|boolean',
@@ -118,6 +118,7 @@ class SettingsRequest extends FormRequest
             // land on the sensible option rather than fail validation.
             'theater_name_position' => $this->input('theater_name_position') ?: 'bottom',
             'poster_fill_scrim' => $this->input('poster_fill_scrim') ?: 'standard',
+            'transition_type' => $this->input('transition_type') ?: 'fade',
             'jellyfin_service' => $this->boolean('jellyfin_service'),
             'show_header_border' => $this->boolean('show_header_border'),
             'validate_movie_titles' => $this->boolean('validate_movie_titles'),

--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -30,13 +30,7 @@
                                 }"
                                 :style="blackBars(poster)"
                             >
-                                <Transition
-                                    :name="
-                                        settings.transition_type === 'fade'
-                                            ? 'fade-poster'
-                                            : 'slide-poster'
-                                    "
-                                >
+                                <Transition :name="transitionPrefix + '-poster'">
                                     <div
                                         v-if="poster.show"
                                         :style="
@@ -154,7 +148,7 @@ export default {
             'theme_music',
             'socket',
         ]),
-        ...mapGetters(usePostersStore, ['mediaPosters']),
+        ...mapGetters(usePostersStore, ['mediaPosters', 'transitionPrefix']),
         fillScreen() {
             return !!this.settings.poster_fill_screen;
         },
@@ -514,5 +508,36 @@ export default {
 }
 .slide-poster-enter-from {
     transform: translate3d(0, 100%, 0);
+}
+
+/*
+ * Cross-fade. Fade runs both halves at once, so mid-change the pair is briefly
+ * half transparent and the background shows through as a dip. Here the
+ * incoming poster fades in on top while the outgoing one holds at full
+ * opacity underneath and is only dropped once it is covered, so the screen
+ * never darkens between posters.
+ */
+.crossfade-poster-enter-active {
+    transition: opacity 1.6s ease;
+    z-index: 2;
+}
+
+.crossfade-poster-enter-from {
+    opacity: 0;
+}
+
+.crossfade-poster-leave-active {
+    transition: opacity 0.01s linear 1.6s;
+    z-index: 1;
+}
+
+.crossfade-poster-leave-to {
+    opacity: 0;
+}
+
+/* Cut. No animation at all - one poster replaces the next outright. */
+.cut-poster-enter-active,
+.cut-poster-leave-active {
+    transition: none;
 }
 </style>

--- a/resources/js/Views/Settings.vue
+++ b/resources/js/Views/Settings.vue
@@ -146,11 +146,17 @@
                                         v-model="settings.transition_type"
                                     >
                                         <option value="fade">Fade</option>
+                                        <option value="crossfade">Cross-fade</option>
                                         <option value="vertical">Vertical</option>
+                                        <option value="cut">Cut</option>
                                     </select>
 
                                     <div id="typeHelp" class="text-gray-400 text-sm">
-                                        Fade in/out or Vertical slide transition.
+                                        How one poster gives way to the next. Fade takes both
+                                        through the background, so the screen dips darker in
+                                        between; cross-fade brings the new one in over the old, so
+                                        it does not. Vertical slides upward, and cut swaps them
+                                        outright with no animation.
                                     </div>
                                 </div>
 
@@ -1743,6 +1749,12 @@ export default {
 
             if (!settings.poster_fill_scrim) {
                 settings.poster_fill_scrim = 'standard';
+            }
+
+            // Same trap as the rating limits: a select bound to null renders
+            // blank rather than showing the option it is really on.
+            if (!settings.transition_type) {
+                settings.transition_type = 'fade';
             }
 
             return settings;

--- a/resources/js/components/bottom-footer.vue
+++ b/resources/js/components/bottom-footer.vue
@@ -30,7 +30,7 @@
     </footer>
 </template>
 <script>
-import { mapState } from 'pinia';
+import { mapGetters, mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
 
 import StarRating from 'vue-star-rating';
@@ -57,11 +57,12 @@ export default {
             'audienceRating',
             'currentPosterId',
         ]),
+        ...mapGetters(usePostersStore, ['transitionPrefix']),
         localRating() {
             return this.nowPlaying ? this.rating : this.audienceRating;
         },
         transitionName() {
-            return this.settings.transition_type === 'fade' ? 'fade-meta' : 'slide-meta';
+            return this.transitionPrefix + '-meta';
         },
         posterKey() {
             return this.nowPlaying ? 'now-playing' : this.currentPosterId;
@@ -146,6 +147,28 @@ export default {
 .slide-meta-enter-from {
     transform: translate3d(0, 100%, 0);
     opacity: 0;
+}
+.crossfade-meta-enter-active {
+    transition: opacity 1.6s ease;
+    z-index: 2;
+}
+
+.crossfade-meta-enter-from {
+    opacity: 0;
+}
+
+.crossfade-meta-leave-active {
+    transition: opacity 0.01s linear 1.6s;
+    z-index: 1;
+}
+
+.crossfade-meta-leave-to {
+    opacity: 0;
+}
+
+.cut-meta-enter-active,
+.cut-meta-leave-active {
+    transition: none;
 }
 .audience-rating {
     display: flex;

--- a/resources/js/components/top-header.vue
+++ b/resources/js/components/top-header.vue
@@ -32,7 +32,7 @@
     </header>
 </template>
 <script>
-import { mapState } from 'pinia';
+import { mapGetters, mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
 import SpeakerConfig from '@/components/speaker-config.vue';
 
@@ -51,6 +51,7 @@ export default {
             'nowPlayingRuntime',
             'currentPosterId',
         ]),
+        ...mapGetters(usePostersStore, ['transitionPrefix']),
         /**
          * The settings API hands booleans back as 0 and 1, so this cannot just
          * test against false - 0 !== false, and the header stayed on. Absent is
@@ -63,7 +64,7 @@ export default {
             return value === undefined || value === null ? true : !!Number(value);
         },
         transitionName() {
-            return this.settings.transition_type === 'fade' ? 'fade-meta' : 'slide-meta';
+            return this.transitionPrefix + '-meta';
         },
         posterKey() {
             return this.nowPlaying ? 'now-playing' : this.currentPosterId;
@@ -181,6 +182,28 @@ export default {
 .slide-meta-enter-from {
     transform: translate3d(0, 100%, 0);
     opacity: 0;
+}
+.crossfade-meta-enter-active {
+    transition: opacity 1.6s ease;
+    z-index: 2;
+}
+
+.crossfade-meta-enter-from {
+    opacity: 0;
+}
+
+.crossfade-meta-leave-active {
+    transition: opacity 0.01s linear 1.6s;
+    z-index: 1;
+}
+
+.crossfade-meta-leave-to {
+    opacity: 0;
+}
+
+.cut-meta-enter-active,
+.cut-meta-leave-active {
+    transition: none;
 }
 
 .runtime {

--- a/resources/js/store/posters.js
+++ b/resources/js/store/posters.js
@@ -68,6 +68,24 @@ export const usePostersStore = defineStore('posters', {
         tvY7Limits: ['TV-Y', 'TV-Y7'],
     }),
     getters: {
+        /**
+         * The class prefix for the chosen transition. Held here so the poster,
+         * the header and the footer cannot drift apart on which effect they are
+         * running - they have to move together to look like one change.
+         *
+         * 'vertical' keeps the older 'slide' prefix so displays that already
+         * chose it are unaffected.
+         */
+        transitionPrefix() {
+            const prefixes = {
+                fade: 'fade',
+                vertical: 'slide',
+                crossfade: 'crossfade',
+                cut: 'cut',
+            };
+
+            return prefixes[this.settings.transition_type] || 'fade';
+        },
         mediaPosters() {
             return this.moviePosters.filter((poster) => {
                 if (poster.media_type === 'movie') {

--- a/tests/Feature/SettingsApiTest.php
+++ b/tests/Feature/SettingsApiTest.php
@@ -98,6 +98,24 @@ class SettingsApiTest extends TestCase
         }
     }
 
+    public function test_every_offered_transition_type_is_accepted(): void
+    {
+        foreach (['fade', 'crossfade', 'vertical', 'cut'] as $type) {
+            $this->putJson('/api/settings', $this->validPayload([
+                'transition_type' => $type,
+            ]))->assertOk();
+
+            $this->assertSame($type, Setting::first()->transition_type);
+        }
+    }
+
+    public function test_an_unknown_transition_type_is_rejected(): void
+    {
+        $this->putJson('/api/settings', $this->validPayload([
+            'transition_type' => 'barrel-roll',
+        ]))->assertStatus(422)->assertJsonValidationErrors('transition_type');
+    }
+
     public function test_the_theater_name_position_only_accepts_top_or_bottom(): void
     {
         $this->putJson('/api/settings', $this->validPayload([


### PR DESCRIPTION
The Transition Type dropdown offered only Fade and Vertical. Adds the two you
asked for.

## Cross-fade

Fade runs both halves at once, so mid-change the pair is briefly half
transparent and the background shows through as a dip. Cross-fade brings the new
poster in **over** the old one, which holds at full opacity underneath until it
is covered, so the screen never darkens between posters:

```
crossfade  enter-active   opacity 1.6s 0s      z-index 2
           leave-active   opacity 0.01s 1.6s   z-index 1
```

Fade is untouched, so anything already set to it looks exactly as before.

## Cut

No animation at all — one poster replaces the next outright:

```
cut  enter-active/leave-active   transition: none
```

## Resolved once, not three times

The effect is now worked out in the store rather than by a ternary in each of
the three places that needed it. The poster, the runtime and the footer details
have to move together to read as one change, and three copies of `'fade' ? … : …`
would not have survived a fourth option. `vertical` keeps the existing `slide`
class prefix, so displays already set to it are unaffected.

Verified the chosen type reaches all three surfaces together:

```
poster    crossfade-poster-enter-active …
footer    footer-row crossfade-meta-enter-active …
runtime   runtime crossfade-meta-enter-active …
```

## Two things tightened while in there

- `transition_type` now validates against the four values the form offers rather
  than accepting any string.
- The select defaults instead of rendering blank when the value has never been
  set — the same trap the rating display limits were in.

176 tests green (2 new, covering all four types and a rejected one), Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)