### PR TITLE
Release 2.1.3

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.1.2",
-    "changelog": "Fixes a poster that looked cut off at the top and bottom when filling the screen: the artwork was full height all along, but the header and footer were sitting on top of it. They now float over the poster, with shading behind them so the text stays readable - how heavy that shading is has its own setting. Also fixes the new display options showing as switched off in Settings when they were on, which could switch them off for real the next time you saved.",
+    "latest": "2.1.3",
+    "changelog": "Two more ways for one poster to give way to the next. Cross-fade brings the new poster in over the old one, so the screen does not dip darker in between the way a plain fade does, and Cut swaps them outright with no animation. Fade and Vertical are unchanged, so a display already set to either looks exactly as it did.",
     "past_updates": [
+        {
+            "version": "2.1.2",
+            "changelog": "Fixes a poster that looked cut off at the top and bottom when filling the screen: the artwork was full height all along, but the header and footer were sitting on top of it. They now float over the poster, with shading behind them so the text stays readable - how heavy that shading is has its own setting. Also fixes the new display options showing as switched off in Settings when they were on, which could switch them off for real the next time you saved."
+        },
         {
             "version": "2.1.1",
             "changelog": "The display now gives the whole screen to a vote while one is running - Vote Now, a large QR code and the countdown - and shows the winner before returning to the slideshow. Voting can be ended early, a session left open closes itself, and the admin console no longer lingers after one ends. New display options: fill the screen with the poster (scaled to fit, never cropped), hide the Coming Soon / Now Playing text, and show your theater name above or below the poster. The rating display limits no longer show blank when no limit is set, and the details around a poster now change with it instead of ahead of it."


### PR DESCRIPTION
Publishes [#26](https://github.com/devMikeFrancis/digital-movie-poster/pull/26).

## What ships

**Two more transition types.**

- **Cross-fade** brings the new poster in over the old one, which holds at full
  opacity underneath until it is covered — so the screen does not dip darker
  between posters the way a plain fade does.
- **Cut** swaps them outright with no animation.

Fade and Vertical are unchanged, so a display already set to either looks
exactly as it did.

Also tightens `transition_type` to validate against the four values the form
offers, and stops the select rendering blank when the value has never been set.

## Installing

From the About screen. No migration in this one; `update.sh` rebuilds the front
end, which is where all of this lives.

176 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)