### PR TITLE
Make the cross-fade actually stack

### DIFF
--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -518,6 +518,13 @@ export default {
  * never darkens between posters.
  */
 .crossfade-poster-enter-active {
+    /*
+     * Positioned so the z-index below is not ignored. The poster's inner div is
+     * static by default, which made both stacking orders inert - and stacking
+     * is the whole mechanism here, since the incoming poster has to be painted
+     * over the outgoing one for the screen not to dip.
+     */
+    position: relative;
     transition: opacity 1.6s ease;
     z-index: 2;
 }
@@ -527,6 +534,7 @@ export default {
 }
 
 .crossfade-poster-leave-active {
+    position: relative;
     transition: opacity 0.01s linear 1.6s;
     z-index: 1;
 }


### PR DESCRIPTION
Reported: cross-fade is doing vertical.

## Two separate things, and only one of them is a code bug

### The vertical is a stale build

Pre-2.1.3 the poster transition was picked like this:

```js
settings.transition_type === 'fade' ? 'fade-poster' : 'slide-poster'
```

Anything that is not `fade` becomes `slide-poster` — vertical. So a display
running 2.1.2 or older JS, with the setting saved as `crossfade`, renders
vertical. It is the old code doing exactly what it was written to do with a
value that did not exist when it was written.

Nothing to fix in the app for that: it resolves when the display is actually on
2.1.3. Worth a hard reload of the browser too, since a tab left open keeps its
old bundle across an update.

### The cross-fade was genuinely broken

The incoming poster has to be painted over the outgoing one — that is the whole
mechanism, and what keeps the screen from dipping darker mid-change. It was
driven by `z-index` on the two active classes, and the element those classes
land on is `position: static`:

```
innerPosition: static   innerZIndex: 2   ->  INERT
```

So both stacking orders were ignored, paint order fell back to document order,
and the result was not a cross-fade. Positioned now, so it applies:

```
crossfade-poster-enter-active   position: relative  z-index: 2  transform: none
crossfade-poster-leave-active   position: relative  z-index: 1  transform: none
```

`transform: none` on both confirms there is no vertical movement in the
cross-fade path itself.

The header and footer versions were never affected — `.runtime` and
`.footer-row` are already absolutely positioned.

## Note

This is a fix to what shipped in 2.1.3 and wants a 2.1.4 to reach devices.

176 tests green, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)