### PR TITLE
Let a second poster be added without leaving the page

### DIFF
--- a/resources/js/Views/PostersEdit.vue
+++ b/resources/js/Views/PostersEdit.vue
@@ -123,6 +123,7 @@
                                         type="file"
                                         class="text-black w-full"
                                         aria-describedby="movie-posterHelp"
+                                        :key="'artwork-' + formGeneration"
                                         @change="selectFile($event)"
                                     />
                                     <div id="movie-posterHelp" class="text-gray-400 text-sm"></div>
@@ -141,6 +142,7 @@
                                         name="music_file"
                                         id="music-unput"
                                         aria-describedby="musicHelp"
+                                        :key="'music-' + formGeneration"
                                         @change="selectMusicFile($event)"
                                     />
                                     <div id="musicHelp" class="text-gray-400 text-sm">
@@ -387,16 +389,7 @@
                                 </div>
 
                                 <button
-                                    class="
-                                        btn
-                                        text-black
-                                        bg-gray-300
-                                        text-md
-                                        px-3
-                                        py-1
-                                        rounded-sm
-                                        hover:bg-gray-100
-                                    "
+                                    class="btn text-black bg-gray-300 text-md px-3 py-1 rounded-sm hover:bg-gray-100"
                                     @click.prevent="savePoster"
                                     :disabled="saving"
                                 >
@@ -424,6 +417,37 @@ import axios from 'axios';
 import MainNav from '../partials/MainNav.vue';
 import TitleLookup from '@/components/title-lookup.vue';
 
+/**
+ * A poster form with nothing filled in.
+ *
+ * Shared by the initial state and the reset so the two cannot drift: the reset
+ * used to blank every property it found, which wiped media_type and the
+ * switches to empty strings and made the next save fail validation.
+ */
+function blankPoster() {
+    return {
+        id: 0,
+        imdb_id: '',
+        media_type: 'movie',
+        name: '',
+        image: null,
+        mpaa_rating: '',
+        audience_rating: '',
+        trailer_path: '',
+        runtime: '',
+        show_trailer: false,
+        show_runtime: true,
+        show_in_rotation: true,
+        play_theme_music: false,
+        show_dolby_atmos: false,
+        show_dolby_51: false,
+        show_dolby_vision: false,
+        show_dtsx: false,
+        show_auro_3d: false,
+        show_imax: false,
+    };
+}
+
 export default {
     data: function () {
         return {
@@ -440,21 +464,10 @@ export default {
             formMessage: '',
             mode: '',
             music: null,
-            poster: {
-                id: '',
-                imdb_id: '',
-                media_type: 'movie',
-                name: '',
-                image: null,
-                mpaa_rating: '',
-                audience_rating: '',
-                trailer_path: '',
-                show_trailer: false,
-                show_runtime: true,
-                show_in_rotation: true,
-                runtime: '',
-                play_theme_music: false,
-            },
+            poster: blankPoster(),
+            // Bumped on reset so the file inputs are rebuilt; clearing the
+            // model does not clear the filename the browser is showing.
+            formGeneration: 0,
             savePosterBtn: 'Save Poster',
             socket: '',
         };
@@ -618,14 +631,14 @@ export default {
                 });
         },
         clearPoster() {
-            for (const prop of Object.getOwnPropertyNames(this.poster)) {
-                this.poster[prop] = '';
-            }
-            this.poster.id = 0;
-            this.poster.show_runtime = 1;
-            this.poster.show_in_rotation = 1;
-            this.poster.image = null;
+            this.poster = blankPoster();
             this.music = null;
+            this.formGeneration += 1;
+            this.errors = [];
+            this.formMessage = '';
+            this.fetchMessage = '';
+            this.fetchFailed = false;
+            this.fetchedArtwork = '';
             this.mode = 'new';
             this.setSavePosterBtn();
         },


### PR DESCRIPTION
Reported: adding multiple posters in one session does not add properly.

## Reproduced

Create a poster, click **Reset to create new poster**, fill in the next one,
save:

```
422  {"message":"The media type field is required.",
      "errors":{"media_type":["The media type field is required."]}}
```

## Cause

`clearPoster()` blanked every property it found on the poster object:

```js
for (const prop of Object.getOwnPropertyNames(this.poster)) {
    this.poster[prop] = '';
}
```

`media_type` is required, so it came back 422 — with nothing on the form to
explain it, because the select had simply gone blank rather than showing an
invalid value.

The deeper reason it blanked the wrong things: by the time the reset runs, the
object is no longer the form's poster. A successful save does
`this.poster = response.data.poster`, so the shape being cleared is the **API
resource** — `file_name`, `ordinal`, `created_at`, `can_delete` and the rest —
not the shape the form was written against. Confirmed by applying the reset to a
real API poster:

```
media_type       -> ""
show_trailer     -> ""
play_theme_music -> ""
show_dolby_atmos -> ""
```

## Fix

One definition of an empty poster, shared by the initial state and the reset, so
the two cannot drift apart again. The reset also clears the messages and bumps a
key on the two file inputs — clearing the model does not clear the filename the
browser is still displaying, which made it look as though the previous artwork
had carried over.

## Verified

Added two posters in one session without leaving the page — Back to the Future,
reset, Groundhog Day — both created with their own artwork, and the first not
overwritten. Test posters removed afterwards, so the library is as it was.

176 tests green, Pint clean. No PHP change, so nothing new to cover there; the
defect was entirely in the editor's reset and there is no JS test harness in
this project to pin it with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)