### PR TITLE
Order the cross-fade on the wrappers, where it can take effect

### DIFF
--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -30,7 +30,13 @@
                                 }"
                                 :style="blackBars(poster)"
                             >
-                                <Transition :name="transitionPrefix + '-poster'">
+                                <Transition
+                                    :name="transitionPrefix + '-poster'"
+                                    @enter="liftPoster"
+                                    @before-leave="sinkPoster"
+                                    @after-leave="resetPosterLayer"
+                                    @leave-cancelled="resetPosterLayer"
+                                >
                                     <div
                                         v-if="poster.show"
                                         :style="
@@ -199,6 +205,61 @@ export default {
 
             if (!this.loading && !this.isPlaying) {
                 this.startTransitionImages();
+            }
+        },
+        /*
+         * Stacking for the cross-fade, applied to each poster's wrapper rather
+         * than to the element the transition classes land on.
+         *
+         * Every poster in the list has its own wrapper, and those wrappers are
+         * fixed with will-change, so each is its own stacking context - a
+         * z-index on the inner element can only order it against its own
+         * siblings, of which it has none. Across wrappers the order was simply
+         * document order, so whether the incoming poster arrived on top of the
+         * outgoing one depended on where the two happened to sit in the list.
+         * Going from the last poster back to the first, it arrived underneath,
+         * and the cross-fade came out as a hard cut.
+         */
+        /*
+         * On enter rather than before-enter: Vue runs before-enter while the
+         * element is still detached, so there is no wrapper to put a z-index on
+         * yet and the lift quietly did nothing. Leaving worked, which made it
+         * look as though only half the mechanism was wired up.
+         */
+        liftPoster(el) {
+            this.setPosterLayer(el, '2');
+        },
+        sinkPoster(el) {
+            // after-leave runs once the element is out of the tree, so note
+            // where it was while it is still possible to.
+            if (el) {
+                el.__posterWrapper = el.parentElement;
+            }
+
+            this.setPosterLayer(el, '1');
+        },
+        setPosterLayer(el, value) {
+            if (this.transitionPrefix !== 'crossfade') {
+                return;
+            }
+
+            if (el && el.parentElement) {
+                el.parentElement.style.zIndex = value;
+            }
+        },
+        /**
+         * Only ever clears the wrapper it is handed. Clearing all of them
+         * looked tidier and was wrong: a late leave from the previous change
+         * wiped the lift the current one had just set, dropping the arriving
+         * poster back underneath.
+         */
+        resetPosterLayer(el) {
+            const wrapper = el && (el.parentElement || el.__posterWrapper);
+
+            // Not guarded on the transition type: clearing an inline z-index is
+            // always safe, and the type may have been changed mid-change.
+            if (wrapper) {
+                wrapper.style.zIndex = '';
             }
         },
         blackBars(poster) {
@@ -517,16 +578,13 @@ export default {
  * opacity underneath and is only dropped once it is covered, so the screen
  * never darkens between posters.
  */
+/*
+ * Ordering is handled on the wrappers in JS - see liftPoster - because each
+ * poster sits in its own stacking context and cannot be ordered against the
+ * others from here.
+ */
 .crossfade-poster-enter-active {
-    /*
-     * Positioned so the z-index below is not ignored. The poster's inner div is
-     * static by default, which made both stacking orders inert - and stacking
-     * is the whole mechanism here, since the incoming poster has to be painted
-     * over the outgoing one for the screen not to dip.
-     */
-    position: relative;
     transition: opacity 1.6s ease;
-    z-index: 2;
 }
 
 .crossfade-poster-enter-from {
@@ -534,9 +592,7 @@ export default {
 }
 
 .crossfade-poster-leave-active {
-    position: relative;
     transition: opacity 0.01s linear 1.6s;
-    z-index: 1;
 }
 
 .crossfade-poster-leave-to {

--- a/tests/js/crossfade-stacking.test.js
+++ b/tests/js/crossfade-stacking.test.js
@@ -1,0 +1,115 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), disconnect: vi.fn() })) }));
+
+import { usePostersStore } from '@/store/posters';
+import Dashboard from '@/Views/Dashboard.vue';
+
+/**
+ * Regression: the cross-fade works by putting the incoming poster over the
+ * outgoing one. That was driven by a z-index on the element the transition
+ * classes land on - but every poster sits in its own wrapper, and those
+ * wrappers are their own stacking contexts, so the inner z-index could only
+ * order an element against siblings it did not have. Across wrappers the order
+ * was document order, so going from the last poster back to the first the new
+ * one arrived underneath and the cross-fade came out as a hard cut.
+ *
+ * The ordering lives on the wrappers now, which is a DOM change rather than a
+ * computed style, so it can be checked here.
+ */
+function dashboard(transitionType) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+
+    const store = usePostersStore();
+    store.settings = { transition_type: transitionType, poster_display_speed: 15000 };
+    store.loading = false;
+
+    return mount(Dashboard, {
+        global: {
+            plugins: [pinia],
+            stubs: { TopHeader: true, BottomFooter: true, TheaterName: true, VotingScreen: true },
+        },
+    });
+}
+
+/** An element inside a poster wrapper, as the transition hooks receive it. */
+function posterElement() {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'poster';
+    const inner = document.createElement('div');
+    wrapper.appendChild(inner);
+    document.body.appendChild(wrapper);
+
+    return inner;
+}
+
+describe('cross-fade stacking', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('lifts the arriving poster above the one it replaces', () => {
+        const vm = dashboard('crossfade').vm;
+        const arriving = posterElement();
+        const leaving = posterElement();
+
+        vm.liftPoster(arriving);
+        vm.sinkPoster(leaving);
+
+        expect(Number(arriving.parentElement.style.zIndex)).toBeGreaterThan(
+            Number(leaving.parentElement.style.zIndex)
+        );
+    });
+
+    it('orders the wrapper, since the inner element cannot order across wrappers', () => {
+        const vm = dashboard('crossfade').vm;
+        const arriving = posterElement();
+
+        vm.liftPoster(arriving);
+
+        expect(arriving.parentElement.style.zIndex).toBe('2');
+        expect(arriving.style.zIndex).toBe('');
+    });
+
+    it('clears only the poster it is handed, not every wrapper', () => {
+        // A late leave from the previous change used to clear the lift the
+        // current one had just set, dropping the arriving poster underneath.
+        const vm = dashboard('crossfade').vm;
+        const arriving = posterElement();
+        const leaving = posterElement();
+
+        vm.liftPoster(arriving);
+        vm.sinkPoster(leaving);
+        vm.resetPosterLayer(leaving);
+
+        expect(leaving.parentElement.style.zIndex).toBe('');
+        expect(arriving.parentElement.style.zIndex).toBe('2');
+    });
+
+    it('clears the wrapper even once the poster has left the tree', () => {
+        // after-leave runs after removal, so the element has no parent by then.
+        const vm = dashboard('crossfade').vm;
+        const leaving = posterElement();
+        const wrapper = leaving.parentElement;
+
+        vm.sinkPoster(leaving);
+        expect(wrapper.style.zIndex).toBe('1');
+
+        leaving.remove();
+        vm.resetPosterLayer(leaving);
+
+        expect(wrapper.style.zIndex).toBe('');
+    });
+
+    it.each(['fade', 'vertical', 'cut'])('leaves %s alone', (type) => {
+        const vm = dashboard(type).vm;
+        const arriving = posterElement();
+
+        vm.liftPoster(arriving);
+
+        expect(arriving.parentElement.style.zIndex).toBe('');
+    });
+});


### PR DESCRIPTION
The 2.1.4 fix did not work. I checked that the `z-index` declaration applied to
the element and stopped there — without checking that it could order that
element against the one it needed to sit above.

## Why it could not work

Every poster sits in its own wrapper, and those wrappers are `fixed` with
`will-change` — so each is its own stacking context. A `z-index` on the inner
element could only order it against siblings it does not have:

```
domIndex 0,1  leaving   innerZIndex 1   wrapperZIndex auto
domIndex 9    entering  innerZIndex 2   wrapperZIndex auto
```

Across wrappers the order was simply document order, so whether the arriving
poster landed on top depended on where the two posters happened to sit in the
list. Going from the last poster back to the first it landed **underneath**, and
the cross-fade came out as a hard cut.

## Two further corrections, both only visible on the display

**The lift never ran.** Vue calls `before-enter` while the element is still
detached, so there was no wrapper to write to and the lift silently did nothing
— while the sink worked, because `before-leave` runs with the element still in
the tree. Half a mechanism, and worse than none: the outgoing poster was raised
above an arriving one that had not been raised at all.

```
enter-active   wrapperZ (none)      <- lift never applied
leave-active   wrapperZ 1           <- sink did
```

It lifts on `enter` now, which runs after insertion.

**Clearing every wrapper at the end** was tidy and wrong: a late leave from the
previous change wiped the lift the current one had just set. Each hook now
clears only the wrapper it was handed, and the leaving element notes its wrapper
on the way out, since `after-leave` runs once it is already gone.

## Verified on the display

```
domIndex 1   leave-active   wrapperZ 1
domIndex 7   enter-active   wrapperZ 2
domIndex 10  leave-active   wrapperZ 1
verdict: arriving poster is above the outgoing one
```

The outgoing poster at index 10 is *later* in document order than the arriving
one at 7 — the exact case that used to fail.

## Now covered

This is a DOM change rather than a computed style, so unlike the original it can
be pinned. Reverting to the inner-element version fails 2 of the new tests.
Also covers the detached-element cleanup.

28 front-end tests, 176 PHP tests, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)