### PR TITLE
Release 2.1.6

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.1.5",
-    "changelog": "Fixes adding several posters in a row. After saving one, \"Reset to create new poster\" cleared the Media Type along with everything else, so the next save was refused for a missing media type with a blank field and no explanation on screen. The reset now leaves the form as it starts out, and clears the artwork and music file pickers with it.",
+    "latest": "2.1.6",
+    "changelog": "Cross-fade really cross-fades now. The previous attempt at it did not take effect, so whether the arriving poster came in over the outgoing one or behind it depended on where the two sat in your poster list - going from the last poster back to the first it came in behind, and the change looked like a hard cut instead.",
     "past_updates": [
+        {
+            "version": "2.1.5",
+            "changelog": "Fixes adding several posters in a row. After saving one, \"Reset to create new poster\" cleared the Media Type along with everything else, so the next save was refused for a missing media type with a blank field and no explanation on screen. The reset now leaves the form as it starts out, and clears the artwork and music file pickers with it."
+        },
         {
             "version": "2.1.4",
             "changelog": "Fixes the Cross-fade transition, which was not stacking the incoming poster over the outgoing one and so was not really cross-fading. If you chose Cross-fade or Cut and the display slid vertically instead, that was a display still running older code: it reads any unfamiliar transition as the vertical slide. Taking this update sorts it, and a browser left open on the display wants a reload afterwards."


### PR DESCRIPTION
Publishes [#33](https://github.com/devMikeFrancis/digital-movie-poster/pull/33).

## What ships

**Cross-fade really cross-fades.** The previous attempt did not take effect, so
whether the arriving poster came in over the outgoing one or behind it depended
on where the two sat in the poster list — going from the last poster back to the
first it came in behind, and the change looked like a hard cut.

The ordering now lives on the poster wrappers, which is where it can actually
apply, and it is covered by tests rather than by inspection.

## Installing

From the About screen. No migration; `update.sh` rebuilds the front end.

176 PHP tests, 28 front-end tests, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)