### PR TITLE
Stop the display going blank

### DIFF
--- a/resources/js/store/posters.js
+++ b/resources/js/store/posters.js
@@ -186,12 +186,17 @@ export const usePostersStore = defineStore('posters', {
                 });
         },
         setInitialPosterView() {
-            let poster = '';
-            if (this.settings.random_order) {
-                poster = this.mediaPosters[this.getRandomPoster()];
-            } else {
-                poster = this.mediaPosters[0];
+            // A rating limit can exclude every poster, and unrated ones are
+            // excluded too - so there is not always a first poster to show.
+            // Reaching for one regardless threw during boot and left the
+            // display blank for good rather than for one change.
+            if (this.mediaPosters.length === 0) {
+                return;
             }
+
+            const poster = this.settings.random_order
+                ? this.mediaPosters[this.getRandomPoster()]
+                : this.mediaPosters[0];
 
             poster.show = true;
 
@@ -263,7 +268,10 @@ export const usePostersStore = defineStore('posters', {
                 return true;
             }
             if (mpaaLimit === 'G') {
-                return poster.mpaa_rating === 'G';
+                // Was reading an undefined 'poster' rather than the rating
+                // passed in, so choosing the strictest limit threw inside the
+                // filter and took the whole poster list with it.
+                return rating === 'G';
             }
             if (mpaaLimit === 'PG') {
                 return this.pgLimits.includes(rating);
@@ -285,7 +293,7 @@ export const usePostersStore = defineStore('posters', {
                 return true;
             }
             if (mpaaLimit === 'TV-Y') {
-                return poster.mpaa_rating === 'TV-Y';
+                return rating === 'TV-Y';
             }
             if (mpaaLimit === 'TV-Y7') {
                 return this.tvY7Limits.includes(rating);
@@ -395,37 +403,54 @@ export const usePostersStore = defineStore('posters', {
             this.show_imax = this.settings.show_imax;
             this.show_dolby_51 = this.settings.show_dolby_51;
         },
-        getRandomPoster() {
-            return Math.floor(Math.random() * this.moviePosters.length);
+        /**
+         * An index into the posters actually on show.
+         *
+         * Drawn against moviePosters before, which is the whole library: with a
+         * rating limit set the shown list is shorter, so the index could land
+         * past its end and leave nothing to show at all.
+         *
+         * Never returns the poster already up either. Doing so meant showing
+         * and then hiding the same object, which left the screen blank until
+         * the next change came round.
+         */
+        getRandomPoster(currentIndex = -1) {
+            const length = this.mediaPosters.length;
+
+            if (length <= 1) {
+                return 0;
+            }
+
+            const index = Math.floor(Math.random() * length);
+
+            return index === currentIndex ? (index + 1) % length : index;
         },
         getInSequencePoster() {
             console.log('GET NEXT POSTER');
-            const len = this.mediaPosters.length;
-            const currIndex = this.mediaPosters.findIndex((poster) => poster.show === true);
-            let poster,
-                pastPoster,
-                activeIndex = 0;
+            const posters = this.mediaPosters;
+            const len = posters.length;
 
-            if (this.settings.random_order) {
-                activeIndex = this.getRandomPoster();
-            } else {
-                activeIndex = currIndex + 1 === len ? 0 : currIndex + 1;
+            if (len === 0) {
+                return null;
             }
 
-            if (len === 1) {
-                poster = this.mediaPosters[0];
-                pastPoster = Object.assign(this.mediaPosters[0], {});
-                poster.show = true;
-            } else {
-                poster = this.mediaPosters[activeIndex];
-                pastPoster = this.mediaPosters[currIndex];
-                if (poster) {
-                    poster.show = true;
-                }
-                if (pastPoster) {
-                    pastPoster.show = false;
-                }
+            const currIndex = posters.findIndex((poster) => poster.show === true);
+            const activeIndex = this.settings.random_order
+                ? this.getRandomPoster(currIndex)
+                : (currIndex + 1) % len;
+
+            const poster = posters[activeIndex];
+            const pastPoster = currIndex > -1 ? posters[currIndex] : null;
+
+            // Hidden first, and never the poster about to be shown: the two
+            // used to be the same object whenever the random pick landed on the
+            // poster already up, and clearing it afterwards left the screen
+            // blank until the next change.
+            if (pastPoster && pastPoster !== poster) {
+                pastPoster.show = false;
             }
+
+            poster.show = true;
 
             return poster;
         },

--- a/tests/js/poster-sequence.test.js
+++ b/tests/js/poster-sequence.test.js
@@ -1,0 +1,120 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), disconnect: vi.fn() })) }));
+
+import { usePostersStore } from '@/store/posters';
+
+/**
+ * Regression: the display occasionally went blank.
+ *
+ * In random order the next poster could be the one already on screen. The old
+ * code then set show on it and cleared show on the poster it was replacing -
+ * the same object - so it ended up hidden and nothing was left showing until
+ * the next change came round.
+ */
+function storeWith(posters, settings = {}) {
+    setActivePinia(createPinia());
+
+    const store = usePostersStore();
+    store.moviePosters = posters;
+    store.settings = { random_order: true, mpaa_limit: '', tv_limit: '', ...settings };
+
+    return store;
+}
+
+function library(count) {
+    return Array.from({ length: count }, (_, i) => ({
+        id: i + 1,
+        name: `Poster ${i + 1}`,
+        media_type: 'movie',
+        mpaa_rating: 'PG',
+        show: i === 0,
+    }));
+}
+
+/** Force the random pick onto a chosen index. */
+function pickIndex(index, length) {
+    vi.spyOn(Math, 'random').mockReturnValue(index / length);
+}
+
+describe('choosing the next poster', () => {
+    beforeEach(() => vi.restoreAllMocks());
+
+    it('always leaves exactly one poster showing when random picks the current one', () => {
+        const store = storeWith(library(4));
+        pickIndex(0, 4); // the poster already on screen
+
+        store.getInSequencePoster();
+
+        expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+    });
+
+    it('never returns nothing to show', () => {
+        const store = storeWith(library(4));
+
+        for (let i = 0; i < 4; i++) {
+            pickIndex(i, 4);
+            const poster = store.getInSequencePoster();
+
+            expect(poster, `picking index ${i} returned nothing`).toBeTruthy();
+            expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+        }
+    });
+
+    it('moves on rather than sitting on the same poster', () => {
+        const store = storeWith(library(4));
+        pickIndex(0, 4);
+
+        const poster = store.getInSequencePoster();
+
+        expect(poster.id).not.toBe(1);
+    });
+
+    it('stays on the only poster when there is just one', () => {
+        const store = storeWith(library(1));
+
+        const poster = store.getInSequencePoster();
+
+        expect(poster.id).toBe(1);
+        expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+    });
+
+    it('picks within the posters actually on show, not the whole library', () => {
+        // A rating limit makes the shown list shorter than the library; the
+        // random index used to be drawn against the library length, so it could
+        // land past the end and leave nothing showing.
+        const posters = library(6);
+        posters.slice(3).forEach((p) => (p.mpaa_rating = 'R'));
+        const store = storeWith(posters, { mpaa_limit: 'PG' });
+
+        expect(store.mediaPosters).toHaveLength(3);
+
+        for (let i = 0; i < 20; i++) {
+            vi.spyOn(Math, 'random').mockReturnValue(0.95);
+            const poster = store.getInSequencePoster();
+
+            expect(poster, 'picked past the end of the shown posters').toBeTruthy();
+            expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+        }
+    });
+
+    it('does not fall over when a rating limit leaves nothing to show', () => {
+        const posters = library(3);
+        posters.forEach((p) => (p.mpaa_rating = 'R'));
+        posters.forEach((p) => (p.show = false));
+        const store = storeWith(posters, { mpaa_limit: 'G' });
+
+        expect(store.mediaPosters).toHaveLength(0);
+        expect(() => store.setInitialPosterView()).not.toThrow();
+        expect(store.getInSequencePoster()).toBeNull();
+    });
+
+    it('walks in order when random order is off', () => {
+        const store = storeWith(library(3), { random_order: false });
+
+        expect(store.getInSequencePoster().id).toBe(2);
+        expect(store.getInSequencePoster().id).toBe(3);
+        expect(store.getInSequencePoster().id).toBe(1);
+    });
+});

--- a/tests/js/rating-limits.test.js
+++ b/tests/js/rating-limits.test.js
@@ -1,0 +1,73 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), disconnect: vi.fn() })) }));
+
+import { usePostersStore } from '@/store/posters';
+
+/**
+ * Regression: the strictest option in each list - G and TV-Y - read an
+ * undefined variable instead of the rating handed in. Choosing either threw
+ * inside the filter that builds the poster list, which took the whole list with
+ * it and left the display blank. They are also the options a parent is most
+ * likely to pick.
+ */
+function store(settings) {
+    setActivePinia(createPinia());
+
+    const s = usePostersStore();
+    s.settings = { mpaa_limit: '', tv_limit: '', ...settings };
+
+    return s;
+}
+
+describe('rating display limits', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it.each([
+        ['G', 'G', true],
+        ['G', 'PG', false],
+        ['G', 'R', false],
+        ['PG', 'G', true],
+        ['PG', 'PG', true],
+        ['PG', 'PG-13', false],
+        ['PG-13', 'PG-13', true],
+        ['PG-13', 'R', false],
+        ['R', 'R', true],
+        ['R', 'NC-17', false],
+    ])('limit %s %s allow %s', (limit, rating, allowed) => {
+        expect(store({ mpaa_limit: limit }).withinMpaaLimit(rating)).toBe(allowed);
+    });
+
+    it.each([
+        ['TV-Y', 'TV-Y', true],
+        ['TV-Y', 'TV-G', false],
+        ['TV-Y', 'TV-MA', false],
+        ['TV-PG', 'TV-G', true],
+        ['TV-PG', 'TV-14', false],
+        ['TV-14', 'TV-14', true],
+        ['TV-14', 'TV-MA', false],
+    ])('TV limit %s %s allow %s', (limit, rating, allowed) => {
+        expect(store({ tv_limit: limit }).withinTvLimit(rating)).toBe(allowed);
+    });
+
+    it('allows everything when no limit is set', () => {
+        const s = store({});
+
+        expect(s.withinMpaaLimit('NC-17')).toBe(true);
+        expect(s.withinTvLimit('TV-MA')).toBe(true);
+    });
+
+    it('builds the poster list without throwing on the strictest limits', () => {
+        for (const settings of [{ mpaa_limit: 'G' }, { tv_limit: 'TV-Y' }]) {
+            const s = store(settings);
+            s.moviePosters = [
+                { id: 1, media_type: 'movie', mpaa_rating: 'G', show: false },
+                { id: 2, media_type: 'tv', mpaa_rating: 'TV-Y', show: false },
+                { id: 3, media_type: 'movie', mpaa_rating: 'R', show: false },
+            ];
+
+            expect(() => s.mediaPosters).not.toThrow();
+        }
+    });
+});


### PR DESCRIPTION
Three separate causes, all reachable from settings people actually use. Your
display has `random_order` on, which makes the first one live.

## 1. Random order could hide the poster it was about to show

The next poster could be the one already on screen. The code then set `show` on
it and cleared `show` on the poster it was replacing — **the same object** — so
nothing was left showing until the next change came round:

```js
poster = this.mediaPosters[activeIndex];   // same object when the pick repeats
pastPoster = this.mediaPosters[currIndex];
if (poster) poster.show = true;
if (pastPoster) pastPoster.show = false;   // turns it straight back off
```

With four posters that is one change in four — the "occasionally" in the report.
The poster to hide is now chosen before the one to show, and a random pick never
lands on the poster already up.

## 2. The random index was drawn against the wrong list

```js
return Math.floor(Math.random() * this.moviePosters.length);   // whole library
```

used to index `mediaPosters`, which is the library **after** the rating limits.
With a limit set the second list is shorter, so the index could land past its end
and leave nothing to show.

## 3. The strictest rating limits threw

```js
if (mpaaLimit === 'G') {
    return poster.mpaa_rating === 'G';   // 'poster' is not defined here
}
```

Same in `withinTvLimit` for `TV-Y`. Choosing either threw inside the filter that
builds the poster list, taking the whole list with it. This one blanks the
display **for good** rather than for one change — and G and TV-Y are the options
a parent is most likely to pick. Found by a test written for cause 1.

Boot also reached for a first poster without checking there was one, which threw
when a limit excluded everything.

## Covered

The sequencing tests fail **four ways** against the old code with the random pick
forced onto the current poster, so these are guards rather than decoration.

```
× always leaves exactly one poster showing when random picks the current one
× never returns nothing to show
× moves on rather than sitting on the same poster
× picks within the posters actually on show, not the whole library
```

54 front-end tests (26 new), 176 PHP tests, Pint clean.

## Note

This wants a 2.1.7 to reach devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)