### PR TITLE
Let the display pick up new posters, and keep one on screen when it does

### DIFF
--- a/resources/js/Views/PostersEdit.vue
+++ b/resources/js/Views/PostersEdit.vue
@@ -414,6 +414,8 @@
 
 <script>
 import axios from 'axios';
+import { mapActions } from 'pinia';
+import { usePostersStore } from '@/store/posters';
 import MainNav from '../partials/MainNav.vue';
 import TitleLookup from '@/components/title-lookup.vue';
 
@@ -475,6 +477,7 @@ export default {
     components: { MainNav, TitleLookup },
     watch: {},
     methods: {
+        ...mapActions(usePostersStore, ['requestDisplayReload']),
         /**
          * Fill the form in from a title the operator picked in the search
          * results, or fetched by IMDB id.
@@ -608,6 +611,11 @@ export default {
                     this.mode = 'edit';
                     this.music = null;
                     this.poster.image = null;
+
+                    // A running display holds the library it loaded with, so a
+                    // poster saved now would not appear on screen until it was
+                    // restarted or refreshed by hand.
+                    this.requestDisplayReload();
 
                     setTimeout(() => {
                         this.setSavePosterBtn();

--- a/resources/js/store/posters.js
+++ b/resources/js/store/posters.js
@@ -488,12 +488,26 @@ export const usePostersStore = defineStore('posters', {
                 .then((response) => {
                     this.stopTransitionImages();
                     this.moviePosters = response.data.posters;
-                    setTimeout(() => {
-                        if (this.loading === true) {
+
+                    // The list that arrives has nothing marked as showing, so
+                    // put a poster up before starting the clock again.
+                    this.setInitialPosterView();
+
+                    if (this.loading) {
+                        setTimeout(() => {
                             this.loading = false;
                             this.startTransitionImages();
-                        }
-                    }, this.bootTime);
+                        }, this.bootTime);
+
+                        return;
+                    }
+
+                    // Not booting, so the screen is live and carries straight
+                    // on. Restarting used to be skipped whenever loading was
+                    // false, which is every routine sync: the transitions
+                    // stopped, the list was replaced with one that had nothing
+                    // showing, and the display sat empty from then on.
+                    this.startTransitionImages();
                 })
                 .catch((e) => {
                     console.log(e.message);
@@ -601,6 +615,12 @@ export const usePostersStore = defineStore('posters', {
         },
         startTransitionImages() {
             console.log('START TRANSITIONS');
+
+            // Cleared first so a second start cannot leave the previous timer
+            // running: two clocks on the same posters change them at odd
+            // intervals, and one change can land before the last has finished.
+            this.stopTransitionImages();
+
             window.transitionImagesInterval = setInterval(() => {
                 this.transitionImages();
             }, this.settings.poster_display_speed);

--- a/resources/js/store/posters.js
+++ b/resources/js/store/posters.js
@@ -2,6 +2,9 @@ import axios from 'axios';
 import { io } from 'socket.io-client';
 import { defineStore } from 'pinia';
 
+/** How often a running display pulls the poster library again. */
+const POSTER_SYNC_MS = 1000 * 60 * 60 * 4;
+
 export const usePostersStore = defineStore('posters', {
     state: () => ({
         loading: true,
@@ -254,13 +257,24 @@ export const usePostersStore = defineStore('posters', {
                 this.useSettingsProLogos();
             }
         },
+        // Four hours, which is what the arithmetic here was meant to say. It
+        // came to a little over twenty-seven years, so a display never picked
+        // up a poster added after it started - the screen kept cycling whatever
+        // was in the library the last time it loaded.
         startSyncPosters() {
-            this.recentlyAddedInterval = setInterval(
-                () => {
-                    this.cachePosters();
-                },
-                60000 * 60 * 60 * 1000 * 4
-            ); // Every 4 hours
+            this.recentlyAddedInterval = setInterval(() => {
+                this.cachePosters();
+            }, POSTER_SYNC_MS);
+        },
+        /**
+         * Tells any display on the network to pull the library again. The same
+         * command the Refresh Movie Posters button sends, so that adding a
+         * poster does not need a second, manual step to be seen.
+         */
+        requestDisplayReload() {
+            if (this.socket && typeof this.socket.emit === 'function') {
+                this.socket.emit('dispatch:command', { command: 'reload' });
+            }
         },
         withinMpaaLimit(rating) {
             let mpaaLimit = this.settings.mpaa_limit;

--- a/tests/js/poster-sync.test.js
+++ b/tests/js/poster-sync.test.js
@@ -1,0 +1,60 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), emit: vi.fn() })) }));
+
+import { usePostersStore } from '@/store/posters';
+
+/**
+ * Regression: a running display never picked up a poster added after it
+ * started. The re-sync interval read 60000 * 60 * 60 * 1000 * 4 with a comment
+ * saying every four hours - it came to a little over twenty-seven years, so the
+ * screen kept cycling whatever was in the library the last time it loaded.
+ */
+describe('keeping the display in step with the library', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => vi.useRealTimers());
+
+    it('schedules the next pull four hours out, not decades out', () => {
+        const store = usePostersStore();
+        const setInterval = vi.spyOn(globalThis, 'setInterval');
+
+        store.startSyncPosters();
+
+        const [, delay] = setInterval.mock.calls[0];
+        const hours = delay / 1000 / 60 / 60;
+
+        expect(hours).toBe(4);
+    });
+
+    it('pulls the library when that comes round', () => {
+        const store = usePostersStore();
+        store.cachePosters = vi.fn();
+
+        store.startSyncPosters();
+        vi.advanceTimersByTime(1000 * 60 * 60 * 4);
+
+        expect(store.cachePosters).toHaveBeenCalledTimes(1);
+    });
+
+    it('asks the display to reload so a saved poster appears without a second step', () => {
+        const store = usePostersStore();
+        const emit = vi.fn();
+        store.socket = { emit };
+
+        store.requestDisplayReload();
+
+        expect(emit).toHaveBeenCalledWith('dispatch:command', { command: 'reload' });
+    });
+
+    it('does nothing when there is no socket to ask', () => {
+        const store = usePostersStore();
+        store.socket = '';
+
+        expect(() => store.requestDisplayReload()).not.toThrow();
+    });
+});

--- a/tests/js/poster-sync.test.js
+++ b/tests/js/poster-sync.test.js
@@ -3,7 +3,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), emit: vi.fn() })) }));
 
+const get = vi.fn();
+vi.mock('axios', () => ({ default: { get: (...args) => get(...args) } }));
+
 import { usePostersStore } from '@/store/posters';
+
+function library(count) {
+    return Array.from({ length: count }, (_, i) => ({
+        id: i + 1,
+        media_type: 'movie',
+        mpaa_rating: 'PG',
+        show: false,
+        runtime: 100,
+        show_runtime: true,
+    }));
+}
 
 /**
  * Regression: a running display never picked up a poster added after it
@@ -49,6 +63,61 @@ describe('keeping the display in step with the library', () => {
         store.requestDisplayReload();
 
         expect(emit).toHaveBeenCalledWith('dispatch:command', { command: 'reload' });
+    });
+
+    it('keeps a poster on screen across a routine sync', async () => {
+        // The fetched list has nothing marked as showing. Swapping it in and
+        // walking away left the screen empty until the next change - and since
+        // the transitions had been stopped and were only restarted while
+        // booting, there was no next change.
+        const store = usePostersStore();
+        store.settings = {
+            random_order: false,
+            mpaa_limit: '',
+            tv_limit: '',
+            poster_display_speed: 15000,
+        };
+        store.moviePosters = library(3);
+        store.loading = false;
+        get.mockResolvedValue({ data: { posters: library(5) } });
+
+        await store.cachePosters();
+
+        expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+    });
+
+    it('starts the clock again after a routine sync', async () => {
+        const store = usePostersStore();
+        store.settings = {
+            random_order: false,
+            mpaa_limit: '',
+            tv_limit: '',
+            poster_display_speed: 15000,
+        };
+        store.moviePosters = library(3);
+        store.loading = false;
+        get.mockResolvedValue({ data: { posters: library(5) } });
+
+        await store.cachePosters();
+        store.transitionImages = vi.fn();
+        vi.advanceTimersByTime(15000);
+
+        expect(window.transitionImagesInterval).toBeTruthy();
+    });
+
+    it('does not leave a second clock running when started twice', () => {
+        const store = usePostersStore();
+        store.settings = { poster_display_speed: 15000 };
+        store.transitionImages = vi.fn();
+
+        store.startTransitionImages();
+        const first = window.transitionImagesInterval;
+        store.startTransitionImages();
+
+        vi.advanceTimersByTime(15000);
+
+        expect(window.transitionImagesInterval).not.toBe(first);
+        expect(store.transitionImages).toHaveBeenCalledTimes(1);
     });
 
     it('does nothing when there is no socket to ask', () => {


### PR DESCRIPTION
Reported: only four titles rotating; then, still occasional blanks.

## Nothing was filtering posters out

```
TOTAL: 11        in rotation: 11
missing file_name: 0        media_type not movie/tv: 0
api returns: 11 posters
```

## The display never asked again

Its re-sync interval read:

```js
60000 * 60 * 60 * 1000 * 4   // Every 4 hours
```

which comes to **864,000,000,000 ms — just over twenty-seven years**. A running
display kept cycling whatever was in the library when it last loaded: four
titles on a screen that started when there were four.

## Correcting that alone would have made things worse

`cachePosters()` stopped the transitions, replaced the poster list with one that
has nothing marked as showing, and then only restarted the clock
`if (this.loading === true)` — true at boot and never afterwards. So a routine
sync **stopped the display, emptied it, and left it that way**.

Unreachable at twenty-seven years. At four hours it would have blanked every
display twice a working day. Caught by a test written for the first fix:

```
shownRightAfterReplace: 0
```

The sync now puts a poster up before starting the clock again, and starts it
whether or not this was the boot.

## And a latent one alongside it

`startTransitionImages()` did not clear the existing timer, so anything that
started it twice left two clocks running on the same posters — changes at odd
intervals, and one change landing before the last had finished, which on a
cross-fade shows as a poster that never quite arrives. It clears first now.

## Four hours is still a long wait

Saving a poster now sends the same refresh the **Refresh Movie Posters** button
sends, so adding one no longer needs a second, separate step.

## Verified

The display renders all eleven, showing a title that had never appeared:

```
posterSlots: 11
rendered: harry-potter-and-the-goblet-of-fire.webp
```

The cycle logic was also stressed over 5,000 changes with the random pick
unconstrained — exactly one poster showing every time.

## Covered

Reverting either fix fails cleanly:

```
AssertionError: expected 240000 to be 4              // hours between syncs
AssertionError: expected [] to have a length of 1    // nothing left showing
AssertionError: expected undefined to be truthy      // clock never restarted
```

61 front-end tests (7 new), 176 PHP tests, Pint clean.

## Note

Wants a 2.1.8. Until then, **Refresh Movie Posters** on the admin sidebar makes
a running display pull the library again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)