### PR TITLE
Credit version 1 to its author, and act on an audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,14 @@ with the code so a change and its explanation arrive together.
 
 ## Credits
 
-Originally created by Don Jones. Maintained by
-[Mike Francis](https://github.com/devMikeFrancis).
+**Don Jones** created DMP and built it through version 1.x — the original
+concept, the poster display, and the media-server integrations it still runs on.
+
+**[Mike Francis](https://github.com/devMikeFrancis)** has maintained it since,
+and version 2.0 is a ground-up refresh of the architecture on that foundation:
+Laravel 9 to 13, SQLite in place of MariaDB, an authenticated admin with
+credentials encrypted at rest, and the display and voting work that has followed.
+Ongoing development continues here.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "authors": [
         {
             "name": "Don Jones",
-            "role": "Creator"
+            "role": "Creator, version 1"
         },
         {
             "name": "Mike Francis",
-            "role": "Maintainer"
+            "role": "Maintainer, version 2 onwards"
         }
     ],
     "require": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,7 @@ Everything beyond the overview in the [project README](../README.md).
 
 There is no GitHub wiki. This directory is the documentation, and it lives with
 the code so a change and its explanation arrive together.
+
+DMP was created by Don Jones, who built version 1. Version 2 onwards — the
+refreshed architecture and continuing development — is by
+[Mike Francis](https://github.com/devMikeFrancis).

--- a/resources/js/Views/About.vue
+++ b/resources/js/Views/About.vue
@@ -53,7 +53,7 @@
                                 </div>
 
                                 <p class="text-white">
-                                    This project is maintained by Mike Francis at
+                                    Version 2 and ongoing development by Mike Francis at
                                     <a
                                         class="text-gray-400 hover:text-white"
                                         href="https://github.com/devMikeFrancis/digital-movie-poster"
@@ -62,7 +62,7 @@
                                     >
                                 </p>
                                 <p class="text-gray-400 text-sm mt-2">
-                                    Originally created by Don Jones.
+                                    Created by Don Jones, who built version 1.
                                 </p>
 
                                 <div class="pt-12">

--- a/resources/js/store/posters.js
+++ b/resources/js/store/posters.js
@@ -5,6 +5,9 @@ import { defineStore } from 'pinia';
 /** How often a running display pulls the poster library again. */
 const POSTER_SYNC_MS = 1000 * 60 * 60 * 4;
 
+/** How long to wait before trying again when the first load fails. */
+const POSTER_RETRY_MS = 5000;
+
 export const usePostersStore = defineStore('posters', {
     state: () => ({
         loading: true,
@@ -139,6 +142,7 @@ export const usePostersStore = defineStore('posters', {
         },
         startSettingsInterval() {
             console.log('START SETTINGS INTERVAL');
+            this.stopSettingsInterval();
             this.settingsInterval = setInterval(() => {
                 this.getSettings();
             }, this.settingsIntervalTime);
@@ -150,7 +154,10 @@ export const usePostersStore = defineStore('posters', {
         getMoviePosters() {
             console.log('GET MOVIE POSTERS');
             this.stopTransitionImages();
-            axios
+
+            // Returned so a caller can wait for it. reloadMoviePosters already
+            // did; this one silently did not.
+            return axios
                 .get('/api/posters?show_in_rotation=true')
                 .then((response) => {
                     this.moviePosters = response.data.posters;
@@ -164,6 +171,14 @@ export const usePostersStore = defineStore('posters', {
                 })
                 .catch((e) => {
                     console.log(e.message);
+
+                    // The slideshow was stopped at the top of this method and
+                    // nothing else will start it, so giving up here leaves the
+                    // display on its loading screen for good. A Pi routinely
+                    // reaches the browser before the web server is answering,
+                    // which is exactly when this fails.
+                    this.loadingMessage = 'Waiting for DMP<br />to answer ...';
+                    setTimeout(() => this.getMoviePosters(), POSTER_RETRY_MS);
                 });
         },
         reloadMoviePosters() {

--- a/tests/js/boot-recovery.test.js
+++ b/tests/js/boot-recovery.test.js
@@ -1,0 +1,73 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), emit: vi.fn() })) }));
+
+const get = vi.fn();
+vi.mock('axios', () => ({ default: { get: (...args) => get(...args) } }));
+
+import { usePostersStore } from '@/store/posters';
+
+/**
+ * A Raspberry Pi routinely reaches the browser before the web server is
+ * answering. The first poster load stops the slideshow before it asks, and
+ * nothing else starts it — so a failure there used to leave the display on its
+ * loading screen for good, with only the message to say why.
+ */
+describe('recovering from a failed first load', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => vi.useRealTimers());
+
+    it('tries again rather than sitting on the loading screen', async () => {
+        const store = usePostersStore();
+        store.settings = { random_order: false, mpaa_limit: '', tv_limit: '' };
+        get.mockRejectedValueOnce(new Error('Network Error'));
+
+        await store.getMoviePosters();
+        expect(get).toHaveBeenCalledTimes(1);
+
+        get.mockResolvedValueOnce({ data: { posters: [] } });
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('says what it is waiting for while it retries', async () => {
+        const store = usePostersStore();
+        get.mockRejectedValueOnce(new Error('Network Error'));
+
+        await store.getMoviePosters();
+
+        expect(store.loadingMessage).toMatch(/waiting for dmp/i);
+    });
+
+    it('comes up properly once the server answers', async () => {
+        const store = usePostersStore();
+        store.settings = { random_order: false, mpaa_limit: '', tv_limit: '' };
+        get.mockRejectedValueOnce(new Error('Network Error'));
+
+        await store.getMoviePosters();
+
+        get.mockResolvedValueOnce({
+            data: { posters: [{ id: 1, media_type: 'movie', mpaa_rating: 'PG', show: false }] },
+        });
+        await vi.advanceTimersByTimeAsync(5000);
+
+        expect(store.mediaPosters.filter((p) => p.show)).toHaveLength(1);
+    });
+
+    it('does not leave a second settings poll running when started twice', () => {
+        const store = usePostersStore();
+        store.getSettings = vi.fn();
+
+        store.startSettingsInterval();
+        store.startSettingsInterval();
+        vi.advanceTimersByTime(store.settingsIntervalTime);
+
+        expect(store.getSettings).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
Two things: the attribution you asked for, and a sweep for more of what the last
bug was.

## Attribution

**Don Jones** created DMP and built it through 1.x — the original concept, the
poster display, and the media-server integrations it still runs on.
**Version 2** is a ground-up refresh of the architecture on that foundation, and
ongoing development continues under
[Mike Francis](https://github.com/devMikeFrancis).

Said that way in the README, the docs index, the About page and `composer.json`.
The `LICENSE` already carried the split copyright (2021-2022 / 2024-2026) and
needed nothing.

## The audit

The last bug was a caller assuming a response shape and an access level it did
not have, and an error path that stopped the display without starting it again.
I looked for more of both.

**All 28 front-end requests checked against the routes they hit** — verb,
authentication and response shape:

- The one authenticated call made from the store, `PUT /posters/{id}/{column}`,
  is only ever reached from admin components — never the display.
- It goes out as a `POST` and carries `_method: 'put'`, so the override is
  correct.
- `PostersCollection` really does declare `$wrap = 'posters'`, which is how
  every caller reads it.

Nothing else was calling something it could not reach. The `cache-posters` case
was the only one, and it is already fixed.

**The undefined-variable class is clear.** The `withinMpaaLimit` bug read a bare
`poster` that was never declared. A scan for the same pattern turned up eight
candidates, and all eight are destructured bindings (`const { data } = ...`) —
false positives. None left.

**Timers all pair up.** Every `setInterval` has a matching `clearInterval`.

## Two things worth fixing came out of it

Both the same shape as the last bug rather than new ones.

**The first poster load could strand the display.** It stops the slideshow
before it asks for anything, and nothing else starts it — so a failure left the
display on its loading screen for good. A Pi routinely reaches the browser
before the web server is answering, which is exactly when this fails. It retries
every five seconds now, and says what it is waiting for.

**`startSettingsInterval` could leave a second poll running**, the same way
`startTransitionImages` could before I fixed it. It clears first now — which is
what `startNowPlayingPolling` already did.

Also returns the poster load's promise, so waiting on it works. It silently did
not, while `reloadMoviePosters` did.

## Covered

Four new tests: the retry fires, the message explains itself, the display comes
up properly once the server answers, and a doubled settings interval polls once.

66 front-end tests, 176 PHP tests, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)