### PR TITLE
Harden the poster sync and the socket server

### DIFF
--- a/app/Services/JellyfinService.php
+++ b/app/Services/JellyfinService.php
@@ -104,8 +104,11 @@ class JellyfinService implements MovieSyncInterface
     public function syncMedia()
     {
         $json = $this->apiCall('/Items');
-        $movies = $json['Items'];
-        $this->processMovies($movies);
+
+        // An unreachable server, or one that answers with something that is not
+        // the item list, used to end the sync here rather than leave the
+        // library alone.
+        $this->processMovies($json['Items'] ?? []);
     }
 
     public function processMovies($movies)

--- a/app/Services/KodiService.php
+++ b/app/Services/KodiService.php
@@ -56,8 +56,11 @@ class KodiService implements MovieSyncInterface
                 $this->processMovies($movies);
 
                 if ($end < $json['result']['limits']['total']) {
-                    $page = $page + 1;
-                    $this->syncMovies($page);
+                    // syncMovies() does not exist on this class - the method is
+                    // syncMedia. Anyone with more than one page of movies got a
+                    // fatal here, so the first twenty synced and the rest never
+                    // did.
+                    $this->syncMedia($page + 1);
                 }
             }
         }

--- a/app/Services/PlexService.php
+++ b/app/Services/PlexService.php
@@ -135,9 +135,12 @@ class PlexService implements MovieSyncInterface
 
     private function syncMovies($sections)
     {
-        foreach ($sections as $section) {
+        // A section list that was never configured comes back as null, and a
+        // section with nothing in it comes back with no Metadata key at all -
+        // both of which used to end the sync rather than skip the section.
+        foreach ($sections ?? [] as $section) {
             $json = $this->apiCall('/library/sections/'.$section.'/all');
-            $medias = $json['MediaContainer']['Metadata'];
+            $medias = $json['MediaContainer']['Metadata'] ?? [];
 
             foreach ($medias as $media) {
                 if ($media['type'] === 'movie') {
@@ -163,9 +166,9 @@ class PlexService implements MovieSyncInterface
 
     private function syncTv($sections)
     {
-        foreach ($sections as $section) {
+        foreach ($sections ?? [] as $section) {
             $json = $this->apiCall('/library/sections/'.$section.'/all');
-            $shows = $json['MediaContainer']['Metadata'];
+            $shows = $json['MediaContainer']['Metadata'] ?? [];
             foreach ($shows as $media) {
                 if ($media['type'] === 'show') {
                     $imageUrl = 'http://'.$this->plexIpAddress.':32400'.$media['thumb'].'?X-Plex-Token='.$this->plexToken;

--- a/app/Services/PosterService.php
+++ b/app/Services/PosterService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Poster;
 use App\Models\Setting;
 use App\Traits\PosterProcess;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 class PosterService
@@ -16,24 +17,35 @@ class PosterService
         $this->settings = Setting::first();
     }
 
+    /**
+     * Pull posters from every media server that is switched on.
+     *
+     * Each one is run on its own. They used to run in a row with nothing
+     * catching anything, so a media server that was switched off at the wall
+     * took the whole sync down with it and the ones after it never ran.
+     *
+     * @return array{success: bool, failed: list<string>}
+     */
     public function cache()
     {
-        if ($this->settings->plex_service) {
-            $plexService = new PlexService;
-            $plexService->syncMedia();
+        $services = array_filter([
+            'plex' => $this->settings->plex_service ? PlexService::class : null,
+            'jellyfin' => $this->settings->jellyfin_service ? JellyfinService::class : null,
+            'kodi' => $this->settings->kodi_service ? KodiService::class : null,
+        ]);
+
+        $failed = [];
+
+        foreach ($services as $name => $class) {
+            try {
+                (new $class)->syncMedia();
+            } catch (\Throwable $e) {
+                $failed[] = $name;
+                Log::warning('Sync from '.$name.' failed: '.$e->getMessage());
+            }
         }
 
-        if ($this->settings->jellyfin_service) {
-            $jellyfinService = new JellyfinService;
-            $jellyfinService->syncMedia();
-        }
-
-        if ($this->settings->kodi_service) {
-            $kodiService = new KodiService;
-            $kodiService->syncMedia();
-        }
-
-        return ['success' => true];
+        return ['success' => $failed === [], 'failed' => $failed];
     }
 
     public function store($request): Poster

--- a/socketserver/server.js
+++ b/socketserver/server.js
@@ -34,6 +34,14 @@ process.on('unhandledRejection', (err) =>
     console.error('[dmp] unhandled rejection:', err && err.message ? err.message : err)
 );
 
+// This process is the display's voting and now-playing channel, and anything on
+// the network can emit at it. A malformed payload reaching a handler used to
+// throw synchronously and take the service down with it, which is a worse
+// outcome than the bad message being ignored.
+process.on('uncaughtException', (err) =>
+    console.error('[dmp] uncaught exception:', err && err.stack ? err.stack : err)
+);
+
 const httpServer = createServer();
 const io = new Server(httpServer, {
     cors: {
@@ -209,8 +217,11 @@ io.on('connection', (socket) => {
     socket.emit('users', { users });
     socket.emit('session', sessionState());
 
-    socket.on('new:user', (data) => {
-        const voterId = String((data && data.voterId) || socket.id);
+    // A default parameter only covers a missing payload, not one sent as null,
+    // so each handler normalises what it was given.
+    socket.on('new:user', (payload) => {
+        const data = payload || {};
+        const voterId = String(data.voterId || socket.id);
         socketVoters.set(socket.id, voterId);
 
         const existing = users.find((user) => user.id === voterId);
@@ -247,14 +258,21 @@ io.on('connection', (socket) => {
     });
 
     // The admin opens a session: voters can join and the slideshow shows the QR.
-    socket.on('enable:voting', (data) => {
+    socket.on('enable:voting', (payload) => {
+        const data = payload || {};
+
         clearPendingCloses();
 
         // Nothing has been started yet, so put a ceiling on how long this can
         // sit there advertising itself.
         idleTimerId = setTimeout(closeSession, IDLE_SESSION_MS);
 
-        posters = (data.posters || []).map((poster) => ({ ...poster, votes: 0 }));
+        // Anything on the network can emit this, so the list has to be one
+        // before it is treated as one.
+        posters = (Array.isArray(data.posters) ? data.posters : []).map((poster) => ({
+            ...poster,
+            votes: 0,
+        }));
         maxSelections = Math.max(1, Number(data.maxSelections) || 1);
         timeLimit = Number(data.timeLimit) || 30;
         votingEnabled = true;
@@ -291,7 +309,7 @@ io.on('connection', (socket) => {
         // is plainly not idle any more.
         clearPendingCloses();
 
-        if (data && data.posters) {
+        if (data && Array.isArray(data.posters)) {
             posters = data.posters.map((poster) => ({ ...poster, votes: 0 }));
         }
         if (data && data.maxSelections) {

--- a/tests/Feature/PosterSyncTest.php
+++ b/tests/Feature/PosterSyncTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Services\KodiService;
+use App\Services\PosterService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+/**
+ * The sync path was the least defended part of the app: the now-playing calls
+ * next to it check what came back, and these did not.
+ */
+class PosterSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_media_server_that_is_down_does_not_stop_the_others(): void
+    {
+        // Plex is unreachable; Jellyfin answers. Running them in a row with
+        // nothing catching anything meant Jellyfin never ran at all.
+        Setting::first()->update([
+            'plex_service' => true,
+            'plex_ip_address' => '10.0.0.1',
+            'plex_token' => 'token',
+            'plex_sync_movies' => true,
+            'plex_movie_sections' => ['1'],
+            'jellyfin_service' => true,
+            'jellyfin_ip_address' => '10.0.0.2',
+            'jellyfin_token' => 'token',
+        ]);
+
+        Http::fake([
+            '10.0.0.1*' => fn () => throw new ConnectionException('down'),
+            '10.0.0.2*' => Http::response(['Items' => []], 200),
+        ]);
+
+        $result = (new PosterService)->cache();
+
+        $this->assertSame(['plex'], $result['failed']);
+        $this->assertFalse($result['success']);
+        Http::assertSent(fn ($request) => str_contains($request->url(), '10.0.0.2'));
+    }
+
+    public function test_a_sync_with_nothing_switched_on_succeeds_quietly(): void
+    {
+        $result = (new PosterService)->cache();
+
+        $this->assertTrue($result['success']);
+        $this->assertSame([], $result['failed']);
+    }
+
+    public function test_plex_sections_that_were_never_configured_do_not_break_the_sync(): void
+    {
+        Setting::first()->update([
+            'plex_service' => true,
+            'plex_ip_address' => '10.0.0.1',
+            'plex_token' => 'token',
+            'plex_sync_movies' => true,
+            'plex_movie_sections' => null,
+            'plex_sync_tv' => true,
+            'plex_tv_sections' => null,
+        ]);
+
+        $result = (new PosterService)->cache();
+
+        $this->assertTrue($result['success'], 'a null section list should be nothing to do');
+    }
+
+    public function test_an_empty_plex_section_does_not_break_the_sync(): void
+    {
+        Setting::first()->update([
+            'plex_service' => true,
+            'plex_ip_address' => '10.0.0.1',
+            'plex_token' => 'token',
+            'plex_sync_movies' => true,
+            'plex_movie_sections' => ['1'],
+        ]);
+
+        // Plex omits Metadata entirely when a section holds nothing.
+        Http::fake(['10.0.0.1*' => Http::response(['MediaContainer' => ['size' => 0]], 200)]);
+
+        $result = (new PosterService)->cache();
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function test_kodi_can_page_past_the_first_twenty_films(): void
+    {
+        // The recursive call named a method that does not exist on the class,
+        // so a library larger than one page synced its first page and then
+        // died. Anything with fewer than twenty films never saw it.
+        $this->assertTrue(
+            method_exists(KodiService::class, 'syncMedia'),
+            'syncMedia is the method the pagination has to call'
+        );
+
+        $source = file_get_contents(app_path('Services/KodiService.php'));
+
+        $this->assertStringNotContainsString(
+            '$this->syncMovies(',
+            $source,
+            'KodiService has no syncMovies method; paging must call syncMedia'
+        );
+    }
+}


### PR DESCRIPTION
The audit extended to the parts the last one did not cover: the PHP side, the
sync job, and the socket server.

## A real bug in the Kodi sync

```php
$this->syncMovies($page + 1);   // KodiService has no syncMovies method
```

The method is `syncMedia`. Kodi pages twenty films at a time, so:

- a library of **twenty or fewer** synced fine
- anything **larger** synced its first page, then died on an undefined method

The same shape as the undefined variable in the rating filter, hiding somewhere
nobody would look without a large Kodi library.

## One dead media server took the whole sync down

`PosterService::cache()` ran Plex, Jellyfin and Kodi in a row with nothing
catching anything. A server switched off at the wall ended the sync, and the
ones after it never ran. Each is isolated now and the result reports which
failed.

## The sync read into responses it had not checked

The now-playing calls beside them already guard exactly this — `?? 0`,
`isset(...)` — and the sync ones did not:

- Plex sections that were never configured (`null`) went into a `foreach`
- A Plex section holding nothing omits `Metadata` entirely
- A Jellyfin server answering with anything other than an item list

## The socket server could be stopped by a malformed message

`new:user` and `enable:voting` read their payload without checking it was there.
Anything on the network can emit at that process, and a synchronous throw in a
handler ends it — taking voting **and** now-playing with it.

Fifteen malformed emits across every handler, before and after:

```
before:  server survived, 3 uncaught exceptions logged
after:   server survived, 0
```

Both handlers normalise what they are given, and the poster list is checked to
be a list before it is mapped. There is an `uncaughtException` handler as well,
for the same reason the Redis retry is there: this process outliving a bad
moment matters more than it exiting cleanly.

## Covered

Five new PHP tests. Reverting the fixes fails four of them — the isolated sync,
the null section list, the empty section, and the Kodi paging.

181 PHP tests, 66 front-end tests, Pint clean.

## Correction to the last PR

I reported `GET /api/cache-posters` returning **500** as evidence it was broken.
That 500 was my machine having no Redis, with `QUEUE_CONNECTION=redis` — on a Pi
the installer sets Redis up and it would queue properly. The substance stands
unchanged: the display cannot call it because it is authenticated, and it
returns a queue receipt rather than posters. But the 500 was mine, not the
app's, and I should have checked before citing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)