### PR TITLE
Swap the poster details instead of overlapping them

### DIFF
--- a/resources/js/components/bottom-footer.vue
+++ b/resources/js/components/bottom-footer.vue
@@ -6,7 +6,7 @@
             is still fading. The row is absolutely placed so the outgoing and
             incoming sets overlap instead of shunting each other sideways.
         -->
-        <Transition :name="transitionName">
+        <Transition :name="transitionName" mode="out-in">
             <div class="footer-row" :key="posterKey">
                 <ContentRating />
                 <ProcessingLogos />
@@ -122,47 +122,42 @@ export default {
     justify-content: center;
 }
 
+/*
+ * The details swap rather than overlap. The poster's cross-fade holds the
+ * outgoing image at full opacity while the incoming one covers it, which works
+ * because a poster covers a poster. These are centred text and icons of
+ * different widths, so nothing covers anything and both sets were readable at
+ * once. With out-in below, the old details leave before the new ones arrive,
+ * and the whole swap still fits inside the poster's change.
+ */
 .fade-meta-enter-active,
-.fade-meta-leave-active {
-    transition: opacity 2.2s ease;
+.fade-meta-leave-active,
+.crossfade-meta-enter-active,
+.crossfade-meta-leave-active {
+    transition: opacity 0.6s ease;
 }
 
 .fade-meta-enter-from,
-.fade-meta-leave-to {
+.fade-meta-leave-to,
+.crossfade-meta-enter-from,
+.crossfade-meta-leave-to {
     opacity: 0;
 }
 
 .slide-meta-enter-active,
 .slide-meta-leave-active {
     transition:
-        transform 1.2s ease,
-        opacity 1s ease;
+        transform 0.5s ease,
+        opacity 0.5s ease;
 }
 
 .slide-meta-leave-to {
-    transform: translate3d(0, -100%, 0);
+    transform: translate3d(0, -60%, 0);
     opacity: 0;
 }
 
 .slide-meta-enter-from {
-    transform: translate3d(0, 100%, 0);
-    opacity: 0;
-}
-.crossfade-meta-enter-active {
-    transition: opacity 1.6s ease;
-    z-index: 2;
-}
-
-.crossfade-meta-enter-from {
-    opacity: 0;
-}
-
-.crossfade-meta-leave-active {
-    transition: opacity 0.01s linear 1.6s;
-    z-index: 1;
-}
-
-.crossfade-meta-leave-to {
+    transform: translate3d(0, 60%, 0);
     opacity: 0;
 }
 

--- a/resources/js/components/top-header.vue
+++ b/resources/js/components/top-header.vue
@@ -1,6 +1,6 @@
 <template>
     <header class="top-header" :style="'background-color:' + settings.header_bg_color">
-        <Transition :name="transitionName">
+        <Transition :name="transitionName" mode="out-in">
             <span
                 class="runtime"
                 v-if="settings.show_runtime && localRuntime"
@@ -157,47 +157,42 @@ export default {
  * The runtime belongs to the poster, so it changes with it rather than
  * snapping to the next film while the artwork is still fading.
  */
+/*
+ * The details swap rather than overlap. The poster's cross-fade holds the
+ * outgoing image at full opacity while the incoming one covers it, which works
+ * because a poster covers a poster. These are centred text and icons of
+ * different widths, so nothing covers anything and both sets were readable at
+ * once. With out-in below, the old details leave before the new ones arrive,
+ * and the whole swap still fits inside the poster's change.
+ */
 .fade-meta-enter-active,
-.fade-meta-leave-active {
-    transition: opacity 2.2s ease;
+.fade-meta-leave-active,
+.crossfade-meta-enter-active,
+.crossfade-meta-leave-active {
+    transition: opacity 0.6s ease;
 }
 
 .fade-meta-enter-from,
-.fade-meta-leave-to {
+.fade-meta-leave-to,
+.crossfade-meta-enter-from,
+.crossfade-meta-leave-to {
     opacity: 0;
 }
 
 .slide-meta-enter-active,
 .slide-meta-leave-active {
     transition:
-        transform 1.2s ease,
-        opacity 1s ease;
+        transform 0.5s ease,
+        opacity 0.5s ease;
 }
 
 .slide-meta-leave-to {
-    transform: translate3d(0, -100%, 0);
+    transform: translate3d(0, -60%, 0);
     opacity: 0;
 }
 
 .slide-meta-enter-from {
-    transform: translate3d(0, 100%, 0);
-    opacity: 0;
-}
-.crossfade-meta-enter-active {
-    transition: opacity 1.6s ease;
-    z-index: 2;
-}
-
-.crossfade-meta-enter-from {
-    opacity: 0;
-}
-
-.crossfade-meta-leave-active {
-    transition: opacity 0.01s linear 1.6s;
-    z-index: 1;
-}
-
-.crossfade-meta-leave-to {
+    transform: translate3d(0, 60%, 0);
     opacity: 0;
 }
 

--- a/tests/js/meta-transition.test.js
+++ b/tests/js/meta-transition.test.js
@@ -1,0 +1,55 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression: the poster's cross-fade holds the outgoing image at full opacity
+ * while the incoming one covers it. That works because a poster covers a
+ * poster. The details around it — the runtime, the content rating, the logos
+ * and the stars — are centred text and icons of different widths, so nothing
+ * covered anything and the old and new sets were readable at the same time.
+ *
+ * out-in is what makes them swap instead: the old details leave before the new
+ * ones arrive.
+ *
+ * These are structural assertions rather than behavioural ones, and that is a
+ * real limit. jsdom gives transitions no duration, so Vue settles them
+ * immediately and a mounted component shows one set either way — the overlap
+ * simply cannot be reproduced here. What can be pinned is the declaration that
+ * prevents it, and the timings that keep the swap inside the poster's change.
+ */
+const components = {
+    'the runtime': 'resources/js/components/top-header.vue',
+    'the footer details': 'resources/js/components/bottom-footer.vue',
+};
+
+describe('the details around the poster', () => {
+    it.each(Object.entries(components))('%s swap rather than overlap', (_name, path) => {
+        const source = readFileSync(path, 'utf8');
+
+        expect(source).toMatch(/<Transition[^>]*mode="out-in"/);
+    });
+
+    it.each(Object.entries(components))(
+        '%s do not hold the outgoing set at full opacity',
+        (_name, path) => {
+            const source = readFileSync(path, 'utf8');
+
+            // The poster's trick: hold, then drop once covered. Nothing covers
+            // these, so holding leaves both readable at once.
+            expect(source).not.toMatch(/crossfade-meta-leave-active[\s\S]{0,120}?linear\s+1\.6s/);
+        }
+    );
+
+    it.each(Object.entries(components))('%s finish inside the poster change', (_name, path) => {
+        const source = readFileSync(path, 'utf8');
+        const durations = [...source.matchAll(/-meta-(?:enter|leave)-active[\s\S]{0,160}?([\d.]+)s/g)]
+            .map((m) => Number(m[1]))
+            .filter((n) => n > 0);
+
+        expect(durations.length).toBeGreaterThan(0);
+
+        // Out and in run back to back, so the pair has to fit inside the
+        // shortest poster transition, which is the 1.6s cross-fade.
+        expect(Math.max(...durations) * 2).toBeLessThanOrEqual(1.6);
+    });
+});


### PR DESCRIPTION
Reported: the rating and data do not cross-fade properly — they overlap.

## Why

The cross-fade holds the outgoing poster at full opacity while the incoming one
fades in over it, then drops it once it is covered:

```css
.crossfade-meta-leave-active { transition: opacity 0.01s linear 1.6s; }
```

That works for the **artwork**, because a poster covers a poster. The details
around it are centred text and icons of different widths, so nothing covers
anything — and both the old and the new set stayed readable at once for the
whole 1.6 seconds.

My mistake was reusing the poster's trick for content it does not suit.

## Fix

They swap rather than overlap: the outgoing details leave before the incoming
ones arrive, six tenths of a second each way, so the pair still fits inside the
shortest poster change.

The other transition types had a milder version of the same thing — two sets of
semi-transparent text crossing over each other — and get the same treatment.

Watched on the running display across a full cycle:

```
worstFooter: 1    worstRuntime: 0    bothVisible: 0
```

Never two sets on screen together.

## A limit worth naming

The tests here are **structural, not behavioural**. jsdom gives transitions no
duration, so Vue settles them immediately and a mounted component shows one set
either way — the overlap cannot be reproduced there. I wrote the behavioural
version first, checked it against the broken code, and it passed both ways, so I
threw it out rather than leave something that looks like cover and is not.

What is pinned: the declaration that prevents the overlap, that the hold is
gone, and that out and in together still fit inside the poster's 1.6 seconds.
Removing `mode="out-in"` fails two of them.

72 front-end tests, 181 PHP tests, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)