### PR TITLE
Release 2.1.12

### DIFF
--- a/public/version.json
+++ b/public/version.json
@@ -1,7 +1,11 @@
 {
-    "latest": "2.1.11",
-    "changelog": "Syncing from Kodi now works for libraries with more than twenty films - past that it synced the first twenty and stopped. A media server that is switched off no longer stops the others from syncing, and a sync no longer gives up when a library section is empty or was never chosen. The socket server behind voting and now-playing also survives a malformed message from anything on the network instead of stopping.",
+    "latest": "2.1.12",
+    "changelog": "The runtime, rating, logos and stars around a poster now swap cleanly when the poster changes. They were fading in over the previous set rather than replacing it, so for a moment both were readable at once.",
     "past_updates": [
+        {
+            "version": "2.1.11",
+            "changelog": "Syncing from Kodi now works for libraries with more than twenty films - past that it synced the first twenty and stopped. A media server that is switched off no longer stops the others from syncing, and a sync no longer gives up when a library section is empty or was never chosen. The socket server behind voting and now-playing also survives a malformed message from anything on the network instead of stopping."
+        },
         {
             "version": "2.1.10",
             "changelog": "A display that starts before the server is ready now waits and tries again, instead of sitting on the loading screen until someone reloads it - which is what happened if the Pi reached the browser first. Also credits version 1 to Don Jones, who created DMP, on the About page."


### PR DESCRIPTION
Publishes [#46](https://github.com/devMikeFrancis/digital-movie-poster/pull/46).

## What ships

**The details around a poster swap cleanly when it changes.** The runtime,
content rating, processing logos and star rating were fading in over the
previous set rather than replacing it, so for a moment both were readable at
once. Most obvious on Cross-fade, milder on the others.

## Installing

From the About screen. No migration; `update.sh` rebuilds the front end.

181 PHP tests, 72 front-end tests, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)