### PR TITLE
Shade only the ends that have something on them

### DIFF
--- a/docs/display.md
+++ b/docs/display.md
@@ -90,6 +90,20 @@ The wording — what it says instead of *Coming Soon* and *Now Playing* — is o
 the same **General** tab. The fonts, sizes, colours and borders are under
 **Settings → Theme**.
 
+## Processing logos
+
+**Which logos to show** decides where the Dolby Atmos, Dolby Vision, DTS:X,
+Auro-3D, IMAX and 5.1 badges come from:
+
+| | |
+| :--- | :--- |
+| **Only the ones each title supports** | The formats set on the poster when you edit it. |
+| **Each title's own, or the ones above if it has none** | Falls back to the global set for titles you have not filled in. |
+| **The ones above, on every title** | Ignores what each title supports and shows the same badges everywhere. |
+
+The last one is why a film with no Atmos soundtrack can end up displaying the
+Atmos logo. Choose the first if the badges should mean something.
+
 ## Limiting what is shown
 
 **Movie Rating Display Limit** and **TV Rating Display Limit** hide anything

--- a/docs/display.md
+++ b/docs/display.md
@@ -44,6 +44,11 @@ the header and footer** controls how heavy that gradient is — *None*, *Subtle*
 a lot before white text over it can be read. Standard is a reasonable starting
 point.
 
+Each end is shaded only when something is actually shown there. Turn off the
+header wording, the runtime, the ratings and the logos and a display shows the
+artwork alone, with no band across either end. It follows whichever end things
+are on, so moving the header or the theatre name moves the shading with it.
+
 A trailer keeps its own box even in fill mode: a video stretched to an arbitrary
 screen shape looks wrong in a way a poster does not.
 

--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -9,7 +9,7 @@
             <div
                 id="recent-added-container"
                 class="poster-container"
-                :class="[{ 'fill-screen': fillScreen }, scrimClass]"
+                :class="[{ 'fill-screen': fillScreen }, scrimClass, scrimSides]"
                 @click.prevent="gotoPosters()"
                 v-if="!isPlaying"
             >
@@ -63,7 +63,7 @@
                 <div
                     id="now-playing-container"
                     class="poster-container"
-                    :class="[{ 'fill-screen': fillScreen }, scrimClass]"
+                    :class="[{ 'fill-screen': fillScreen }, scrimClass, scrimSides]"
                     v-if="isPlaying"
                     @click.prevent="gotoPosters()"
                 >
@@ -164,6 +164,59 @@ export default {
             const choice = this.settings.poster_fill_scrim || 'standard';
 
             return this.fillScreen ? 'scrim-' + choice : '';
+        },
+        /**
+         * The shading exists to keep text readable over artwork, so an end with
+         * nothing on it does not get any - otherwise a display showing only a
+         * poster still had a dark band across the top and bottom of it.
+         *
+         * Worked out from the settings rather than from what happens to be on
+         * screen: a scrim that came and went with each poster's runtime would
+         * be worse than one that is simply there or not.
+         */
+        scrimSides() {
+            if (!this.fillScreen) {
+                return '';
+            }
+
+            return [
+                this.topHasContent ? '' : 'no-scrim-top',
+                this.bottomHasContent ? '' : 'no-scrim-bottom',
+            ].filter(Boolean);
+        },
+        headerHasContent() {
+            const settings = this.settings;
+            const headerText = settings.show_header_text;
+            const textShown =
+                headerText === undefined || headerText === null ? true : !!Number(headerText);
+
+            return !!(
+                textShown ||
+                settings.show_runtime ||
+                (settings.show_speaker_config && settings.speaker_config_location === 'top-right')
+            );
+        },
+        footerHasContent() {
+            const settings = this.settings;
+
+            return !!(
+                settings.show_mpaa_rating ||
+                settings.show_processing_logos ||
+                settings.show_audience_rating ||
+                (settings.show_speaker_config && settings.speaker_config_location === 'bottom')
+            );
+        },
+        topHasContent() {
+            return (
+                (this.headerOn === 'top' && this.headerHasContent) || this.theaterNameOn === 'top'
+            );
+        },
+        bottomHasContent() {
+            return (
+                (this.headerOn === 'bottom' && this.headerHasContent) ||
+                this.theaterNameOn === 'bottom' ||
+                this.footerHasContent
+            );
         },
         headerOn() {
             return this.settings.header_position === 'bottom' ? 'bottom' : 'top';
@@ -484,6 +537,15 @@ export default {
  */
 .scrim-none::before,
 .scrim-none::after {
+    display: none;
+}
+
+/* Nothing at that end to make readable, so nothing to shade. */
+.no-scrim-top::before {
+    display: none;
+}
+
+.no-scrim-bottom::after {
     display: none;
 }
 

--- a/resources/js/Views/Settings.vue
+++ b/resources/js/Views/Settings.vue
@@ -698,29 +698,33 @@
                                     </div>
 
                                     <label
-                                        class="text-gray-300 block mb-3 font-bold flex items-center"
-                                        ><input
-                                            class="text-black"
-                                            type="checkbox"
-                                            v-model="settings.use_global_prologos"
-                                        />
-                                        <span class="ml-2"
-                                            >Use processing logos from global settings</span
-                                        >
+                                        for="prologo-source"
+                                        class="text-gray-300 block mb-2 font-bold"
+                                    >
+                                        Which logos to show
                                     </label>
-                                    <label
-                                        class="text-gray-300 block mb-3 font-bold flex items-center"
-                                        ><input
-                                            class="text-black"
-                                            type="checkbox"
-                                            v-model="
-                                                settings.use_global_prologos_if_no_poster_prologos
-                                            "
-                                        />
-                                        <span class="ml-2"
-                                            >Use global processing logos if no poster logos</span
-                                        >
-                                    </label>
+                                    <select
+                                        class="text-black"
+                                        id="prologo-source"
+                                        aria-describedby="prologoSourceHelp"
+                                        v-model="prologoSource"
+                                    >
+                                        <option value="poster">
+                                            Only the ones each title supports
+                                        </option>
+                                        <option value="poster-then-global">
+                                            Each title's own, or the ones above if it has none
+                                        </option>
+                                        <option value="global">
+                                            The ones above, on every title
+                                        </option>
+                                    </select>
+                                    <div id="prologoSourceHelp" class="text-gray-400 text-sm mt-1">
+                                        A title's own formats are set when you edit it. The last
+                                        option ignores them and shows the same logos everywhere,
+                                        which is why a film with no Atmos soundtrack can end up
+                                        displaying the Atmos logo.
+                                    </div>
                                 </div>
 
                                 <hr class="mt-3 mb-7 border-gray-700" />
@@ -1710,6 +1714,28 @@ export default {
                 return 'text-amber-300';
             }
             return 'text-green-400';
+        },
+        /**
+         * The two flags underneath are really one decision, and as a pair of
+         * checkboxes they did not say what they did: the first overrides every
+         * title, which is not what "use logos from global settings" sounds
+         * like. Presented as the three states they can actually be in.
+         */
+        prologoSource: {
+            get() {
+                if (this.settings.use_global_prologos) {
+                    return 'global';
+                }
+
+                return this.settings.use_global_prologos_if_no_poster_prologos
+                    ? 'poster-then-global'
+                    : 'poster';
+            },
+            set(value) {
+                this.settings.use_global_prologos = value === 'global';
+                this.settings.use_global_prologos_if_no_poster_prologos =
+                    value === 'poster-then-global';
+            },
         },
         saveButtonClass() {
             return this.unsavedChanges && !this.saving

--- a/resources/js/components/processing-logos.vue
+++ b/resources/js/components/processing-logos.vue
@@ -81,8 +81,15 @@
         </div>
 
         <div class="dolby-vision-stacked" v-if="show_dolby_vision_vertical">
+            <!--
+                The bounding box the drawing tool exported came with this, and
+                its fill:none rule lived in the standalone file's stylesheet
+                rather than travelling with the markup - so inlined here it fell
+                back to the SVG default of black and put a solid rectangle
+                behind the logo. Every other logo's box sits inside a
+                g fill="none" and was fine.
+            -->
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 993 363.46">
-                <rect class="cls-1" x="-116" y="-122.95" width="1224.66" height="609.54" />
                 <g>
                     <rect
                         :style="'fill: ' + settings.footer_text_color"

--- a/tests/js/processing-logos.test.js
+++ b/tests/js/processing-logos.test.js
@@ -1,0 +1,81 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { readFileSync } from 'node:fs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('axios', () => ({
+    default: { get: vi.fn(() => Promise.resolve({ data: {} })), post: vi.fn() },
+}));
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), disconnect: vi.fn() })) }));
+
+import Settings from '@/Views/Settings.vue';
+
+/**
+ * The two flags behind this are one decision, and as a pair of checkboxes they
+ * did not say what they did - the first overrides every title, which is not
+ * what "use logos from global settings" sounds like. A film with no Atmos
+ * soundtrack showing the Atmos logo is that setting working as written.
+ */
+function settingsScreen() {
+    return mount(Settings, {
+        global: { plugins: [createPinia()], stubs: { MainNav: true, 'router-link': true } },
+    });
+}
+
+describe('which processing logos to show', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it.each([
+        ['poster', false, false],
+        ['poster-then-global', false, true],
+        ['global', true, false],
+    ])('%s maps onto the two stored flags', (choice, useGlobal, fallBack) => {
+        const vm = settingsScreen().vm;
+
+        vm.prologoSource = choice;
+
+        expect(vm.settings.use_global_prologos).toBe(useGlobal);
+        expect(vm.settings.use_global_prologos_if_no_poster_prologos).toBe(fallBack);
+    });
+
+    it.each([
+        [{ use_global_prologos: true, use_global_prologos_if_no_poster_prologos: false }, 'global'],
+        [
+            { use_global_prologos: false, use_global_prologos_if_no_poster_prologos: true },
+            'poster-then-global',
+        ],
+        [
+            { use_global_prologos: false, use_global_prologos_if_no_poster_prologos: false },
+            'poster',
+        ],
+    ])('reads back what is stored', (stored, expected) => {
+        const vm = settingsScreen().vm;
+
+        Object.assign(vm.settings, stored);
+
+        expect(vm.prologoSource).toBe(expected);
+    });
+
+    it('leaves nothing opaque behind the Dolby Vision logo', () => {
+        // The bounding box exported with this logo kept its fill:none in the
+        // standalone file's stylesheet, which did not travel with the markup -
+        // so inlined it fell back to the SVG default of black.
+        const source = readFileSync('resources/js/components/processing-logos.vue', 'utf8');
+
+        expect(source).not.toContain('class="cls-1"');
+    });
+
+    it('opens each logo with something that has a fill', () => {
+        // The one that broke was a bounding box sitting directly inside <svg>,
+        // where there is no group fill to inherit. Shapes deeper in the markup
+        // sit inside a g fill="none" and are fine, so this checks the position
+        // that actually went wrong rather than guessing at ancestry.
+        const source = readFileSync('resources/js/components/processing-logos.vue', 'utf8');
+
+        const bare = [...source.matchAll(/<svg\b[^>]*>\s*<(rect|path|polygon)\b([^>]*)>/g)].filter(
+            (m) => !/fill|:style|style=/.test(m[2])
+        );
+
+        expect(bare.map((m) => m[0].slice(-70))).toEqual([]);
+    });
+});

--- a/tests/js/scrim-sides.test.js
+++ b/tests/js/scrim-sides.test.js
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('socket.io-client', () => ({ io: vi.fn(() => ({ on: vi.fn(), emit: vi.fn() })) }));
+
+import { usePostersStore } from '@/store/posters';
+import Dashboard from '@/Views/Dashboard.vue';
+
+/**
+ * The shading behind the header and footer exists to keep text readable over
+ * artwork. An end with nothing on it does not need any — a display showing only
+ * a poster was getting a dark band across the top and bottom of it regardless.
+ */
+function dashboard(settings) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+
+    const store = usePostersStore();
+    store.settings = {
+        poster_fill_screen: true,
+        poster_fill_scrim: 'standard',
+        transition_type: 'fade',
+        show_header_text: false,
+        show_runtime: false,
+        show_speaker_config: false,
+        show_mpaa_rating: false,
+        show_processing_logos: false,
+        show_audience_rating: false,
+        show_theater_name: false,
+        header_position: 'top',
+        ...settings,
+    };
+    store.loading = false;
+
+    return mount(Dashboard, {
+        global: {
+            plugins: [pinia],
+            stubs: { TopHeader: true, BottomFooter: true, TheaterName: true, VotingScreen: true },
+        },
+    }).vm;
+}
+
+const sides = (vm) => ({ top: vm.topHasContent, bottom: vm.bottomHasContent });
+
+describe('shading only where there is something to shade', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it('shades neither end of a display showing only artwork', () => {
+        expect(sides(dashboard({}))).toEqual({ top: false, bottom: false });
+    });
+
+    it('shades the top for the header wording', () => {
+        expect(sides(dashboard({ show_header_text: true }))).toEqual({ top: true, bottom: false });
+    });
+
+    it('shades the top for the runtime alone', () => {
+        expect(sides(dashboard({ show_runtime: true }))).toEqual({ top: true, bottom: false });
+    });
+
+    it.each([
+        ['the content rating', 'show_mpaa_rating'],
+        ['the processing logos', 'show_processing_logos'],
+        ['the audience rating', 'show_audience_rating'],
+    ])('shades the bottom for %s', (_label, setting) => {
+        expect(sides(dashboard({ [setting]: true }))).toEqual({ top: false, bottom: true });
+    });
+
+    it('follows the theatre name to whichever end it is on', () => {
+        const shown = { show_theater_name: true, theater_name: 'The Roxy' };
+
+        expect(sides(dashboard({ ...shown, theater_name_position: 'top' })))
+            .toEqual({ top: true, bottom: false });
+        expect(sides(dashboard({ ...shown, theater_name_position: 'bottom' })))
+            .toEqual({ top: false, bottom: true });
+    });
+
+    it('follows the header to whichever end it is on', () => {
+        expect(sides(dashboard({ show_header_text: true, header_position: 'bottom' })))
+            .toEqual({ top: false, bottom: true });
+    });
+
+    it('follows the speaker config to its own corner', () => {
+        const on = { show_speaker_config: true };
+
+        expect(sides(dashboard({ ...on, speaker_config_location: 'top-right' })))
+            .toEqual({ top: true, bottom: false });
+        expect(sides(dashboard({ ...on, speaker_config_location: 'bottom' })))
+            .toEqual({ top: false, bottom: true });
+    });
+
+    it('suppresses each end independently', () => {
+        const vm = dashboard({ show_header_text: true });
+
+        expect(vm.scrimSides).toContain('no-scrim-bottom');
+        expect(vm.scrimSides).not.toContain('no-scrim-top');
+    });
+
+    it('does nothing outside fill mode, where the poster is boxed anyway', () => {
+        const vm = dashboard({ poster_fill_screen: false });
+
+        expect(vm.scrimSides).toBe('');
+    });
+});


### PR DESCRIPTION
The shading behind the header and footer exists to keep text readable over
artwork — so an end with nothing on it does not need any.

A display set up to show only the poster (no header wording, no runtime, no
ratings, no logos) still had a **dark band across the top and bottom**, shading
nothing.

## The rule

It follows the **options**, not what a particular poster happens to carry. An
end is shaded when something is set to appear there:

| Setting | End |
| :--- | :--- |
| Show the Coming Soon / Now Playing text | wherever the header is |
| Show Runtime | wherever the header is |
| Show Media Rating | bottom |
| Show Audience Rating | bottom |
| Show Processing Logos | bottom |
| Show the theater name | wherever the name is |
| Speaker config | its own corner |

`Play Theme Music` and the rating display limits are ignored — neither puts
anything on screen.

Moving the header or the theatre name moves the shading with it.

## Why the options rather than the content

The runtime is the case that decides it: it only renders for a poster that has
one, so a mixed library would gain and lose its top shading between posters. A
scrim that flickers is worse than one that is simply there or not.

The consequence is that a display with the runtime enabled and no poster
carrying one keeps a top scrim it does not strictly need, and that is the right
way round.

The one thing read from content is whether a theatre name has been typed at all
— and that is the same condition that decides whether the name renders in the
first place, so an empty name means nothing is drawn and nothing is shaded.

## Verified on the running display

```
artwork only          no-scrim-top no-scrim-bottom   top hidden, bottom hidden
stars in the footer   no-scrim-top                   top hidden, bottom shown
theatre name at top   no-scrim-bottom                top shown,  bottom hidden
```

## Covered

11 new tests: one per thing that can appear at either end, the two ends being
independent, and none of it applying outside fill mode — where the poster is
boxed between header and footer and never needed shading.

198 PHP tests, 84 front-end tests, Pint clean.

## Note

This wants a 2.1.15 to reach devices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)