### PR TITLE
fix: make spanning the width spread the words, not just the box

### DIFF
--- a/docs/display.md
+++ b/docs/display.md
@@ -60,8 +60,14 @@ and a display that already had that box was carried over to it, so nothing
 changed appearance on updating.
 
 The header can sit **above or below the poster**, and either plate can **span
-the width of the screen** instead of hugging its words — the rules stretch, the
-bulbs repeat across, and a plaque becomes a band.
+the width of the screen** instead of hugging its words. Every style spans in the
+way that style can: the rules stretch, the bulbs repeat across, a plaque becomes
+a band, and the words themselves spread out to reach both edges — except under
+*rules*, where the hairlines grow into the space instead and the words stay as
+they are.
+
+A spanned header keeps clear of the runtime and the speaker badge, which sit
+over the header rather than in the row with it.
 
 **Show the theater name** puts the name of the room the display is in above or
 below the poster, in whichever font the header is using.

--- a/resources/js/components/theater-name.vue
+++ b/resources/js/components/theater-name.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="theater-name" :style="plateVars">
-        <span class="dmp-plate" :class="plateClasses">
-            <span class="dmp-plate-text" :style="nameFont">{{ settings.theater_name }}</span>
+        <span ref="plate" class="dmp-plate" :class="plateClasses">
+            <span ref="plateText" class="dmp-plate-text" :style="nameFont">{{
+                settings.theater_name
+            }}</span>
         </span>
     </div>
 </template>
@@ -9,6 +11,7 @@
 <script>
 import { mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
+import spreadsText from '@/mixins/spreads-text';
 
 /**
  * The name of the room the display is in, above or below the poster.
@@ -20,18 +23,37 @@ import { usePostersStore } from '@/store/posters';
  */
 export default {
     name: 'TheaterName',
+    mixins: [spreadsText],
     computed: {
         ...mapState(usePostersStore, ['settings']),
-        plateClasses() {
+        plateStyleName() {
             const styles = ['plain', 'rules', 'marquee', 'plaque', 'neon'];
-            const chosen = styles.includes(this.settings.theater_name_style)
+
+            return styles.includes(this.settings.theater_name_style)
                 ? this.settings.theater_name_style
                 : 'plain';
-
+        },
+        plateClasses() {
             return [
-                'dmp-plate--' + chosen,
+                'dmp-plate--' + this.plateStyleName,
                 { 'dmp-plate--full': !!this.settings.theater_name_full_width },
             ];
+        },
+        /**
+         * Rules already fill the width - the hairlines grow into whatever the
+         * words leave behind, so spreading the words would leave them nothing
+         * to draw. Every other style spans something of its own and looks
+         * lopsided with a short line of type marooned in the middle of it.
+         */
+        plateSpreads() {
+            return !!this.settings.theater_name_full_width && this.plateStyleName !== 'rules';
+        },
+        spreadKey() {
+            return [
+                this.settings.theater_name,
+                this.settings.header_font,
+                this.plateStyleName,
+            ].join('|');
         },
         /**
          * The decorations are drawn with currentColor, so they only need the

--- a/resources/js/components/top-header.vue
+++ b/resources/js/components/top-header.vue
@@ -1,5 +1,12 @@
 <template>
-    <header class="top-header" :style="'background-color:' + settings.header_bg_color">
+    <header
+        class="top-header"
+        :class="{
+            'reserve-runtime': plateSpreads && settings.show_runtime,
+            'reserve-speaker': plateSpreads && speakerInHeader,
+        }"
+        :style="'background-color:' + settings.header_bg_color"
+    >
         <Transition :name="transitionName" mode="out-in">
             <span
                 class="runtime"
@@ -9,23 +16,31 @@
                 >{{ localRuntime }} min</span
             >
         </Transition>
-        <span v-if="showHeaderText" class="dmp-plate" :class="plateClasses" :style="plateVars">
-            <h1 class="dmp-plate-text" :style="headerSize + headerFont">{{ headerText }}</h1>
+        <span
+            v-if="showHeaderText"
+            ref="plate"
+            class="dmp-plate"
+            :class="plateClasses"
+            :style="plateVars"
+        >
+            <h1 ref="plateText" class="dmp-plate-text" :style="headerSize + headerFont">
+                {{ headerText }}
+            </h1>
         </span>
-        <SpeakerConfig
-            v-if="settings.speaker_config_location === 'top-right' && settings.show_speaker_config"
-        />
+        <SpeakerConfig v-if="speakerInHeader" />
     </header>
 </template>
 <script>
 import { mapGetters, mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
 import SpeakerConfig from '@/components/speaker-config.vue';
+import spreadsText from '@/mixins/spreads-text';
 
 export default {
     data: function () {
         return {};
     },
+    mixins: [spreadsText],
     components: {
         SpeakerConfig,
     },
@@ -52,16 +67,45 @@ export default {
         transitionName() {
             return this.transitionPrefix + '-meta';
         },
-        plateClasses() {
+        speakerInHeader() {
+            return (
+                this.settings.speaker_config_location === 'top-right' &&
+                !!this.settings.show_speaker_config
+            );
+        },
+        plateStyleName() {
             const styles = ['plain', 'rules', 'marquee', 'plaque', 'neon'];
-            const chosen = styles.includes(this.settings.header_style)
+
+            return styles.includes(this.settings.header_style)
                 ? this.settings.header_style
                 : 'plain';
-
+        },
+        plateClasses() {
             return [
-                'dmp-plate--' + chosen,
+                'dmp-plate--' + this.plateStyleName,
                 { 'dmp-plate--full': !!this.settings.header_full_width },
             ];
+        },
+        /**
+         * Rules already fill the width - the hairlines grow into whatever the
+         * words leave behind, so spreading the words would leave them nothing
+         * to draw. Every other style spans something of its own and looks
+         * lopsided with a short line of type marooned in the middle of it.
+         */
+        plateSpreads() {
+            return !!this.settings.header_full_width && this.plateStyleName !== 'rules';
+        },
+        spreadKey() {
+            return [
+                this.showHeaderText,
+                this.headerText,
+                this.settings.header_font,
+                this.settings.header_font_size,
+                this.plateStyleName,
+                // These two decide how much room the line is left with.
+                this.settings.show_runtime,
+                this.speakerInHeader,
+            ].join('|');
         },
         /**
          * The decorations draw themselves in currentColor. A plaque keeps its
@@ -209,6 +253,24 @@ export default {
     transition: none;
 }
 
+/*
+ * The runtime and the speaker badge float over the header rather than sitting
+ * in the row with it, so a line of text spread to the full width runs straight
+ * underneath them. These keep it clear of the space they take.
+ *
+ * A fixed reserve rather than a measurement of the badges: the runtime changes
+ * with every poster, and reserving its exact width would shift the header text
+ * a little on every change. The numbers are the offset each badge is positioned
+ * at plus room for its longest sensible contents at its own type size.
+ */
+.top-header.reserve-runtime {
+    padding-left: 16vw;
+}
+
+.top-header.reserve-speaker {
+    padding-right: 13vw;
+}
+
 .runtime {
     position: absolute;
     top: 50%;
@@ -229,6 +291,10 @@ export default {
     .runtime {
         font-size: 1.4vw;
         left: 5%;
+    }
+    // Smaller type here, so the reserve above is more than it needs.
+    .top-header.reserve-runtime {
+        padding-left: 11vw;
     }
 }
 </style>

--- a/resources/js/mixins/spreads-text.js
+++ b/resources/js/mixins/spreads-text.js
@@ -1,0 +1,82 @@
+import { spreadToWidth, clearSpread } from '@/support/spread-text';
+
+/**
+ * Keeps a plate's text spread to the plate's width.
+ *
+ * The measuring is the easy half; knowing when to measure again is the rest of
+ * it. The line has to be re-spread when the screen changes size, when the
+ * wording changes, and when the typeface finally arrives - a display boots
+ * with the fallback face in place, and a line measured against that one is the
+ * wrong width the moment the real one loads.
+ *
+ * The component supplies:
+ *   - ref="plate" on the plate, ref="plateText" on the words inside it
+ *   - plateSpreads, whether this plate should be spreading at all
+ *   - spreadKey, anything else that changes the width of the line
+ */
+export default {
+    computed: {
+        /** Re-measure whenever any of this moves. */
+        spreadWatch() {
+            return [this.plateSpreads, this.spreadKey].join('|');
+        },
+    },
+    watch: {
+        spreadWatch() {
+            this.scheduleSpread();
+        },
+    },
+    mounted() {
+        // The root rather than the plate: the plate can be behind a v-if and
+        // not exist yet, and it is the width of the root that decides the
+        // width of the plate anyway.
+        this.spreadObserver = new ResizeObserver(() => this.applySpread());
+        this.spreadObserver.observe(this.$el);
+
+        // Belt and braces. The display itself never changes size, but a
+        // browser window previewing it does, and an observer is not delivered
+        // in every environment this runs in.
+        this.spreadOnResize = () => this.applySpread();
+        window.addEventListener('resize', this.spreadOnResize);
+
+        this.scheduleSpread();
+
+        if (document.fonts && document.fonts.ready) {
+            document.fonts.ready.then(() => this.applySpread());
+        }
+    },
+    beforeUnmount() {
+        if (this.spreadObserver) {
+            this.spreadObserver.disconnect();
+            this.spreadObserver = null;
+        }
+
+        window.removeEventListener('resize', this.spreadOnResize);
+    },
+    methods: {
+        /**
+         * Wait for the render that changed the wording before measuring it,
+         * otherwise the old line gets measured and the new one wears the
+         * answer.
+         */
+        scheduleSpread() {
+            this.$nextTick(() => this.applySpread());
+        },
+        applySpread() {
+            const text = this.$refs.plateText;
+            const plate = this.$refs.plate;
+
+            if (!text || !plate) {
+                return;
+            }
+
+            if (!this.plateSpreads) {
+                clearSpread(text);
+
+                return;
+            }
+
+            spreadToWidth(text, plate);
+        },
+    },
+};

--- a/resources/js/support/spread-text.js
+++ b/resources/js/support/spread-text.js
@@ -1,0 +1,119 @@
+/*
+ * Spreading a line of text to the width of its box.
+ *
+ * "Span the width of the screen" made the plate span and left the words where
+ * they were, so for a plain or neon plate the option did nothing you could see:
+ * a 1228px box with 262px of text centred in it. Widening the tracking spans
+ * the words themselves, and unlike growing the type it leaves the line height
+ * alone, so turning it on does not shove the artwork around.
+ */
+
+// Far enough that the second measurement is clearly different, small enough
+// that a long line does not have to reflow into something absurd to be read.
+const PROBE_PX = 10;
+
+/**
+ * The letter-spacing that makes one line of text exactly fill a width.
+ *
+ * Width is linear in letter-spacing - every character gets the same addition -
+ * so two measurements describe the whole line and the answer falls straight
+ * out of them. Creeping up on it in a loop would reflow a dozen times per
+ * resize to land on the same number.
+ *
+ * @param {(spacing: number) => number} measure width in px at a given spacing
+ * @param {number} available width to fill, in px
+ * @param {number} base the spacing the stylesheet already asks for, in px
+ * @returns {number} spacing in px, never tighter than base
+ */
+export function solveSpacing(measure, available, base = 0) {
+    const natural = measure(base);
+    const probed = measure(base + PROBE_PX);
+    const perPixel = (probed - natural) / PROBE_PX;
+
+    // Nothing to spread, or nothing measured - a hidden element measures zero,
+    // and dividing by that would hand back Infinity.
+    if (!(perPixel > 0) || !(natural > 0) || !(available > 0)) {
+        return base;
+    }
+
+    const spacing = base + (available - natural) / perPixel;
+
+    // A name already too long for the screen is left alone rather than being
+    // squeezed tighter than the design asks for.
+    return spacing > base ? spacing : base;
+}
+
+/**
+ * The width a plate has to offer its text: its own, less whatever padding the
+ * decoration takes for itself.
+ */
+export function availableWidth(box, view = window) {
+    const style = view.getComputedStyle(box);
+
+    return (
+        box.clientWidth -
+        (parseFloat(style.paddingLeft) || 0) -
+        (parseFloat(style.paddingRight) || 0)
+    );
+}
+
+/**
+ * Measure and apply, against real elements.
+ *
+ * Two details that are not obvious from the arithmetic:
+ *
+ * The text is measured at max-content, so that the box it is about to fill
+ * cannot clamp the reading - a probe wide enough to wrap would report no gain
+ * for the extra spacing, and the line would stay where it was.
+ *
+ * letter-spacing lands after the last character as well, so a line spread to
+ * the full width sits one gap left of where it should. The trailing gap is
+ * taken back with a negative margin rather than balanced with a matching
+ * indent: an indent pays for the gap twice, and the words end up inset from
+ * both edges of the very box they were asked to span.
+ *
+ * @returns {number} the spacing applied, in px
+ */
+export function spreadToWidth(text, box, view = window) {
+    const inline = text.style;
+    const width = inline.width;
+    const maxWidth = inline.maxWidth;
+
+    inline.width = 'max-content';
+    inline.maxWidth = 'none';
+    inline.whiteSpace = 'nowrap';
+    // The stylesheet indents by one gap to re-centre the line at its natural
+    // width; the negative margin below does that job here instead.
+    inline.textIndent = '0px';
+
+    const base = parseFloat(view.getComputedStyle(text).letterSpacing) || 0;
+
+    const spacing = solveSpacing(
+        (value) => {
+            inline.letterSpacing = value + 'px';
+            inline.marginRight = -value + 'px';
+
+            return text.getBoundingClientRect().width - value;
+        },
+        availableWidth(box, view),
+        base,
+    );
+
+    inline.width = width;
+    inline.maxWidth = maxWidth;
+    inline.letterSpacing = spacing + 'px';
+    inline.marginRight = -spacing + 'px';
+
+    return spacing;
+}
+
+/**
+ * Clear a spread, so a plate that stops spanning goes back to the stylesheet's
+ * own tracking rather than keeping the last width it was measured at.
+ */
+export function clearSpread(text) {
+    text.style.letterSpacing = '';
+    text.style.marginRight = '';
+    text.style.whiteSpace = '';
+    text.style.textIndent = '';
+}

--- a/tests/js/setup.js
+++ b/tests/js/setup.js
@@ -1,0 +1,16 @@
+/**
+ * jsdom parses and styles but does not lay out, so it has no ResizeObserver.
+ * Components that keep text fitted to its box observe their own size, and
+ * without this they cannot be mounted at all.
+ *
+ * The stub does nothing on purpose: a test environment with no layout has no
+ * size changes to report, and everything that depends on measurement is tested
+ * against the measuring functions directly rather than through the DOM.
+ */
+if (!globalThis.ResizeObserver) {
+    globalThis.ResizeObserver = class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    };
+}

--- a/tests/js/spread-text.test.js
+++ b/tests/js/spread-text.test.js
@@ -1,0 +1,197 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { availableWidth, solveSpacing } from '@/support/spread-text';
+import { usePostersStore } from '@/store/posters';
+import TheaterName from '@/components/theater-name.vue';
+import TopHeader from '@/components/top-header.vue';
+
+/**
+ * Regression: "span the width of the screen" stretched the plate and left the
+ * words where they were, so on a plain or neon plate the option did nothing you
+ * could see - a 1228px box with 262px of text centred in it.
+ *
+ * The measuring itself needs layout, which jsdom does not do, so these drive
+ * the solver with a stand-in for the browser's measurements and check the
+ * components' own decisions about when to spread separately.
+ */
+
+/** A line of `characters` glyphs, each `glyph` wide, plus one gap per glyph. */
+function line(characters, glyph) {
+    return (spacing) => characters * glyph + characters * spacing;
+}
+
+function plate(component, settings) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    usePostersStore().settings = { transition_type: 'fade', ...settings };
+
+    return mount(component, {
+        global: { plugins: [pinia], stubs: { SpeakerConfig: true } },
+    });
+}
+
+describe('solving for the spacing that fills a width', () => {
+    it('lands on the width exactly', () => {
+        const measure = line(15, 17);
+
+        const spacing = solveSpacing(measure, 1228);
+
+        expect(measure(spacing)).toBeCloseTo(1228, 6);
+    });
+
+    it('lands on the width exactly when the stylesheet already tracks the text', () => {
+        const measure = line(15, 17);
+
+        const spacing = solveSpacing(measure, 1228, 3);
+
+        expect(measure(spacing)).toBeCloseTo(1228, 6);
+    });
+
+    it('leaves a line that is already too wide at the spacing it was given', () => {
+        // A theatre name longer than the screen must not be squeezed tighter
+        // than the design asks for to make it fit.
+        expect(solveSpacing(line(90, 17), 1228, 3)).toBe(3);
+    });
+
+    it('leaves a hidden element alone', () => {
+        // Everything measures zero before the display has laid out, and the
+        // slope of nothing would set the spacing to Infinity.
+        expect(solveSpacing(() => 0, 1228, 3)).toBe(3);
+    });
+
+    it('leaves the line alone when there is no width to fill', () => {
+        expect(solveSpacing(line(15, 17), 0, 3)).toBe(3);
+    });
+});
+
+describe('the width a plate has to offer', () => {
+    it('is what is left after the decoration takes its padding', () => {
+        const box = { clientWidth: 1228 };
+        const view = {
+            getComputedStyle: () => ({
+                paddingLeft: '30px',
+                paddingRight: '30px',
+            }),
+        };
+
+        expect(availableWidth(box, view)).toBe(1168);
+    });
+
+    it('is the whole plate when the style has no padding', () => {
+        const box = { clientWidth: 1228 };
+        const view = {
+            getComputedStyle: () => ({ paddingLeft: '', paddingRight: '' }),
+        };
+
+        expect(availableWidth(box, view)).toBe(1228);
+    });
+});
+
+describe('which theatre name plates spread', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it('spreads a plain plate, which has no decoration of its own to span', () => {
+        const name = plate(TheaterName, {
+            theater_name: 'Reference Level',
+            theater_name_style: 'plain',
+            theater_name_full_width: true,
+        });
+
+        expect(name.vm.plateSpreads).toBe(true);
+    });
+
+    it('spreads a neon plate', () => {
+        const name = plate(TheaterName, {
+            theater_name: 'Reference Level',
+            theater_name_style: 'neon',
+            theater_name_full_width: true,
+        });
+
+        expect(name.vm.plateSpreads).toBe(true);
+    });
+
+    it('leaves a rules plate alone, because the hairlines do the spanning', () => {
+        const name = plate(TheaterName, {
+            theater_name: 'Reference Level',
+            theater_name_style: 'rules',
+            theater_name_full_width: true,
+        });
+
+        expect(name.vm.plateSpreads).toBe(false);
+    });
+
+    it('does not spread a plate that was not asked to span', () => {
+        const name = plate(TheaterName, {
+            theater_name: 'Reference Level',
+            theater_name_style: 'neon',
+            theater_name_full_width: false,
+        });
+
+        expect(name.vm.plateSpreads).toBe(false);
+    });
+
+    it('marks the plate as full width so the decoration spans too', () => {
+        const name = plate(TheaterName, {
+            theater_name: 'Reference Level',
+            theater_name_style: 'marquee',
+            theater_name_full_width: true,
+        });
+
+        expect(name.find('.dmp-plate').classes()).toContain('dmp-plate--full');
+    });
+});
+
+describe('the header keeping clear of the badges over it', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    /**
+     * Regression: the runtime and the speaker badge are positioned over the
+     * header rather than laid out in the row with it, so a line spread to the
+     * full width ran straight underneath both of them.
+     */
+    it('reserves the runtime end when a spread header shows one', () => {
+        const header = plate(TopHeader, {
+            show_header_text: true,
+            header_full_width: true,
+            show_runtime: true,
+        });
+
+        expect(header.classes()).toContain('reserve-runtime');
+    });
+
+    it('reserves the speaker end when a spread header shows the badge', () => {
+        const header = plate(TopHeader, {
+            show_header_text: true,
+            header_full_width: true,
+            show_speaker_config: true,
+            speaker_config_location: 'top-right',
+        });
+
+        expect(header.classes()).toContain('reserve-speaker');
+    });
+
+    it('does not reserve the speaker end when the badge sits under the poster', () => {
+        const header = plate(TopHeader, {
+            show_header_text: true,
+            header_full_width: true,
+            show_speaker_config: true,
+            speaker_config_location: 'bottom',
+        });
+
+        expect(header.classes()).not.toContain('reserve-speaker');
+    });
+
+    it('reserves nothing on a header that hugs its words', () => {
+        const header = plate(TopHeader, {
+            show_header_text: true,
+            header_full_width: false,
+            show_runtime: true,
+            show_speaker_config: true,
+            speaker_config_location: 'top-right',
+        });
+
+        expect(header.classes()).not.toContain('reserve-runtime');
+        expect(header.classes()).not.toContain('reserve-speaker');
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -20,6 +20,7 @@ export default defineConfig({
     test: {
         environment: 'jsdom',
         include: ['tests/js/**/*.test.js'],
+        setupFiles: ['./tests/js/setup.js'],
         restoreMocks: true,
     },
 });


### PR DESCRIPTION
**Theater name is not properly spanning the text.**

Measured on the running display with the reporter's own settings — neon plate, span the width on: the plate spanned **1228px of the 1280px screen** and the words sat in the middle at their natural **262px**. The option stretched an invisible box.

Same gap on the header, which carries the same control.

## What spanning means now

Every style spans in the way that style can:

| | |
| :--- | :--- |
| **Rules** | The hairlines stretch — unchanged. |
| **Marquee** | The bulbs run the full width, and the name runs with them. |
| **Plaque** | The border becomes a band, with the name spread across it. |
| **Plain / Neon** | The words themselves spread to reach both edges. |

Rules are the one exception to spreading the words: the hairlines grow into whatever the words leave behind, so spreading the words would leave them nothing to draw.

## How the spacing is found

Solved, not guessed. Text width is linear in letter-spacing — every character gets the same addition — so two measurements describe the whole line and the answer falls straight out of them, instead of a loop reflowing a dozen times per resize to land on the same number.

The trailing gap is taken back with a negative margin rather than balanced with a matching indent: `letter-spacing` lands after the last character too, and an indent pays for that gap twice, leaving the words inset from both edges of the very box they were asked to span.

## The header's floating badges

The runtime and the speaker badge are positioned *over* the header, not laid out in the row with it. A hugging line of text left room for them by accident; a spread one ran straight underneath both. A spread header now reserves the ends they occupy.

The reserve is fixed rather than measured — the runtime changes with every poster, and reserving its exact width would shift the header text a little on every change.

## Verification

Measured on the running display at 1280×720: every style checked by screenshot, and the fitted line lands on the plate width to within 0.003px at 900px, 1100px and 1280px.

**A limitation to state plainly:** the measuring needs layout, which jsdom does not do, so the tests drive the solver directly against a stand-in for the browser's measurements and check the components' own decisions about *when* to spread separately. The re-fit-on-resize path was verified by hand in the browser — neither `ResizeObserver` nor the `resize` event is delivered in the automation pane, so a `resize` was dispatched manually and the line re-fitted from 1056px to 1229px as it should. A `window.resize` listener sits alongside the observer for the same reason.

16 new tests, 89 front-end tests green. Confirmed failing when the fix is reverted.

## Note

This branches from `main`, not from #53. `docs/display.md` is touched in both, in different sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)