### PR TITLE
fix: give the top of the screen to the header and the theater name alone

### DIFF
--- a/app/Http/Requests/SettingsRequest.php
+++ b/app/Http/Requests/SettingsRequest.php
@@ -86,7 +86,6 @@ class SettingsRequest extends FormRequest
             'plex_movie_sections' => 'nullable',
             'plex_tv_sections' => 'nullable',
             'speaker_config' => 'nullable|string|max:20',
-            'speaker_config_location' => 'nullable|string',
             'show_speaker_config' => 'required|boolean',
         ];
     }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -76,7 +76,6 @@ class Setting extends Model
         'plex_show_movie_now_playing',
         'plex_show_tv_now_playing',
         'speaker_config',
-        'speaker_config_location',
         'show_speaker_config',
     ];
 

--- a/database/migrations/2026_08_19_000007_drop_speaker_config_location.php
+++ b/database/migrations/2026_08_19_000007_drop_speaker_config_location.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Drops the speaker badge's location.
+ *
+ * It could sit at the top right, floating over the header. The top of the
+ * screen now carries only the header wording and the theatre name - the runtime
+ * moved down with it - so there is one place left for the badge and nothing to
+ * choose between.
+ *
+ * A display set to top-right loses nothing but the position: the badge is still
+ * shown, in the footer with the rating and the logos.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('settings', 'speaker_config_location')) {
+            return;
+        }
+
+        Schema::table('settings', function (Blueprint $table) {
+            $table->dropColumn('speaker_config_location');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            $table->string('speaker_config_location', 50)->default('bottom');
+        });
+    }
+};

--- a/docs/display.md
+++ b/docs/display.md
@@ -22,10 +22,10 @@ or *Poster details*.
 fifteen second setting with a cross-fade is about thirteen seconds of stillness
 and a second and a half of movement.
 
-The details around the poster — the runtime in the header, and the content
-rating, processing logos and star rating in the footer — belong to the poster on
-screen, so they change with it under the same transition rather than snapping to
-the next film while the artwork is still fading.
+The details around the poster — the content rating, the runtime, the processing
+logos, the speaker badge and the star rating, all in the footer — belong to the
+poster on screen, so they change with it under the same transition rather than
+snapping to the next film while the artwork is still fading.
 
 ## Filling the screen
 
@@ -42,8 +42,8 @@ a lot before white text over it can be read. Standard is a reasonable starting
 point.
 
 Each end is shaded only when something is actually shown there. Turn off the
-header wording, the runtime, the ratings and the logos and a display shows the
-artwork alone, with no band across either end. It follows whichever end things
+header wording, the theatre name, the ratings, the runtime and the logos and a
+display shows the artwork alone, with no band across either end. It follows whichever end things
 are on, so moving the header or the theatre name moves the shading with it.
 
 A trailer keeps its own box even in fill mode: a video stretched to an arbitrary
@@ -52,12 +52,13 @@ screen shape looks wrong in a way a poster does not.
 ## The text on screen
 
 **Show the Coming Soon / Now Playing text** turns the header wording off for a
-display that should show only artwork. The runtime and the rest of the header
-are unaffected.
+display that should show only artwork. With it off and no theatre name at the
+top, nothing is drawn there at all — the top of the screen carries the wording
+and the theatre name and nothing else.
 
 **Header plate** dresses the wording with the same five options as the theatre
 name below — plain, rules, marquee bulbs, plaque or neon. *Plaque* is the box
-the header used to have; it keeps its own border colour from the **Theme** tab,
+the header used to have; it keeps its own border colour, set on the same tab,
 and a display that already had that box was carried over to it, so nothing
 changed appearance on updating.
 
@@ -68,8 +69,9 @@ a band, and the words themselves spread out to reach both edges — except under
 *rules*, where the hairlines grow into the space instead and the words stay as
 they are.
 
-A spanned header keeps clear of the runtime and the speaker badge, which sit
-over the header rather than in the row with it.
+A spanned plate takes a small gutter at each end rather than running into the
+bezel, which matters most for a plaque — its border would otherwise sit on the
+very edge of the screen and read as cut off.
 
 **Show the theater name** puts the name of the room the display is in above or
 below the poster, in whichever font the header is using.

--- a/resources/js/Views/Dashboard.vue
+++ b/resources/js/Views/Dashboard.vue
@@ -190,11 +190,9 @@ export default {
             const textShown =
                 headerText === undefined || headerText === null ? true : !!Number(headerText);
 
-            return !!(
-                textShown ||
-                settings.show_runtime ||
-                (settings.show_speaker_config && settings.speaker_config_location === 'top-right')
-            );
+            // The header carries only the wording now; the runtime and the
+            // speaker badge moved down to the footer.
+            return textShown;
         },
         footerHasContent() {
             const settings = this.settings;
@@ -203,7 +201,8 @@ export default {
                 settings.show_mpaa_rating ||
                 settings.show_processing_logos ||
                 settings.show_audience_rating ||
-                (settings.show_speaker_config && settings.speaker_config_location === 'bottom')
+                settings.show_runtime ||
+                settings.show_speaker_config
             );
         },
         topHasContent() {

--- a/resources/js/Views/Display.vue
+++ b/resources/js/Views/Display.vue
@@ -552,7 +552,7 @@
                                         <span class="ml-2">Show Runtime</span>
                                     </label>
                                     <div id="show-runtimeHelp" class="text-gray-400 text-sm">
-                                        Displays the movie runtime in the top left corner.
+                                        Shown in the footer, beside the rating.
                                     </div>
                                 </div>
                                 <div class="mb-5">
@@ -627,22 +627,9 @@
                                             id="speakerConfigHelp"
                                             class="text-gray-400 text-sm mt-1"
                                         >
-                                            Such as 5.1, 7.1.2 or 9.4.6.
+                                            Such as 5.1, 7.1.2 or 9.4.6. It sits in the footer with
+                                            the rating and the logos.
                                         </div>
-
-                                        <label
-                                            for="speaker-config-location"
-                                            class="text-gray-300 block mt-3 mb-2 font-bold"
-                                            >Where it sits</label
-                                        >
-                                        <select
-                                            class="text-black"
-                                            id="speaker-config-location"
-                                            v-model="settings.speaker_config_location"
-                                        >
-                                            <option value="bottom">Bottom</option>
-                                            <option value="top-right">Top right</option>
-                                        </select>
                                     </div>
                                 </div>
                                 <hr class="mt-3 mb-7 border-gray-700" />

--- a/resources/js/components/bottom-footer.vue
+++ b/resources/js/components/bottom-footer.vue
@@ -9,7 +9,22 @@
         <Transition :name="transitionName" mode="out-in">
             <div class="footer-row" :key="posterKey">
                 <ContentRating />
+
+                <span
+                    class="runtime"
+                    v-if="settings.show_runtime && localRuntime"
+                    :style="'color:' + settings.footer_text_color"
+                    >{{ localRuntime }} min</span
+                >
+
                 <ProcessingLogos />
+
+                <!--
+                    Not a processing logo, and it used to be rendered inside
+                    that component - so switching the logos off took the speaker
+                    badge with it, however the badge's own setting was left.
+                -->
+                <SpeakerConfig />
 
                 <div class="audience-rating" v-if="settings.show_audience_rating">
                     <star-rating
@@ -35,6 +50,7 @@ import { usePostersStore } from '@/store/posters';
 
 import StarRating from 'vue-star-rating';
 import ProcessingLogos from '@/components/processing-logos.vue';
+import SpeakerConfig from '@/components/speaker-config.vue';
 import ContentRating from '@/components/content-rating.vue';
 
 export default {
@@ -47,6 +63,7 @@ export default {
     components: {
         StarRating,
         ProcessingLogos,
+        SpeakerConfig,
         ContentRating,
     },
     computed: {
@@ -55,11 +72,18 @@ export default {
             'nowPlaying',
             'rating',
             'audienceRating',
+            'runtime',
+            'nowPlayingRuntime',
             'currentPosterId',
         ]),
         ...mapGetters(usePostersStore, ['transitionPrefix']),
         localRating() {
             return this.nowPlaying ? this.rating : this.audienceRating;
+        },
+        localRuntime() {
+            const rt = this.nowPlaying ? this.nowPlayingRuntime : this.runtime;
+
+            return rt ? rt.toFixed(0) : false;
         },
         transitionName() {
             return this.transitionPrefix + '-meta';
@@ -165,6 +189,19 @@ export default {
 .cut-meta-leave-active {
     transition: none;
 }
+/*
+ * Sits beside the content rating at the left of the row, and rides the row's
+ * own swap - it used to be positioned over the header with a Transition of its
+ * own to do the same job.
+ */
+.runtime {
+    font-size: 2vw;
+    font-weight: 400;
+    line-height: 1;
+    white-space: nowrap;
+    margin-left: 1.5vw;
+}
+
 .audience-rating {
     display: flex;
     align-items: center;
@@ -186,6 +223,19 @@ export default {
         min-height: 13.5vh;
         padding: 2.8vh;
     }
+    /*
+ * Sits beside the content rating at the left of the row, and rides the row's
+ * own swap - it used to be positioned over the header with a Transition of its
+ * own to do the same job.
+ */
+    .runtime {
+        font-size: 2vw;
+        font-weight: 400;
+        line-height: 1;
+        white-space: nowrap;
+        margin-left: 1.5vw;
+    }
+
     .audience-rating {
         width: 14vh;
     }

--- a/resources/js/components/processing-logos.vue
+++ b/resources/js/components/processing-logos.vue
@@ -296,22 +296,15 @@
                 </g>
             </svg>
         </div>
-        <SpeakerConfig
-            v-if="settings.speaker_config_location === 'bottom' && settings.show_speaker_config"
-        />
     </div>
 </template>
 <script>
 import { mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
-import SpeakerConfig from '@/components/speaker-config.vue';
 
 export default {
     data: function () {
         return {};
-    },
-    components: {
-        SpeakerConfig,
     },
     computed: {
         ...mapState(usePostersStore, [

--- a/resources/js/components/speaker-config.vue
+++ b/resources/js/components/speaker-config.vue
@@ -1,15 +1,8 @@
 <template>
-    <div
-        :class="{ 'speaker-config-bottom': settings.speaker_config_location === 'bottom' }"
-        v-if="settings.show_speaker_config"
-    >
+    <div class="speaker-config-bottom" v-if="settings.show_speaker_config">
         <span
-            class="speaker-config rounded-md px-1 border-3"
-            :class="{
-                'speaker-config-top': settings.speaker_config_location === 'top-right',
-                'speaker-config-bottom': settings.speaker_config_location === 'bottom',
-            }"
-            :style="'border-color:' + color + '; text-color: ' + color"
+            class="speaker-config speaker-config-bottom rounded-md px-1 border-3"
+            :style="'border-color:' + settings.footer_text_color"
         >
             <span class="speaker-config-text">{{ settings.speaker_config }}</span>
         </span>
@@ -19,25 +12,19 @@
 import { mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
 
+/**
+ * The room's speaker layout, in the footer with the rest of what describes the
+ * screen rather than the film.
+ *
+ * It could once sit at the top right instead, floating over the header. That
+ * put it in the way of a header spread across the width, and the top of the
+ * screen now carries only the header wording and the theatre name.
+ */
 export default {
     name: 'SpeakerConfig',
-    data: function () {
-        return {};
-    },
     computed: {
         ...mapState(usePostersStore, ['settings']),
-        color() {
-            if (this.settings.speaker_config_location === 'bottom') {
-                return this.settings.footer_text_color;
-            }
-            if (this.settings.speaker_config_location === 'top-right') {
-                return this.settings.header_text_color;
-            }
-            return '#ffffff';
-        },
     },
-    methods: {},
-    mounted() {},
 };
 </script>
 <style lang="scss" scoped>
@@ -45,13 +32,6 @@ export default {
     font-size: 2vw;
     font-weight: 400;
     line-height: 1;
-}
-.speaker-config-top {
-    position: absolute;
-    right: 4%;
-    top: 50%;
-    transform: translateY(-50%);
-    font-size: 1.8vw;
 }
 
 .speaker-config-bottom {

--- a/resources/js/components/top-header.vue
+++ b/resources/js/components/top-header.vue
@@ -1,21 +1,9 @@
 <template>
     <header
         class="top-header"
-        :class="{
-            'reserve-runtime': plateSpreads && settings.show_runtime,
-            'reserve-speaker': plateSpreads && speakerInHeader,
-        }"
+        :class="{ 'top-header--spread': plateSpreads }"
         :style="'background-color:' + settings.header_bg_color"
     >
-        <Transition :name="transitionName" mode="out-in">
-            <span
-                class="runtime"
-                v-if="settings.show_runtime && localRuntime"
-                :key="posterKey"
-                :style="'color:' + settings.header_text_color"
-                >{{ localRuntime }} min</span
-            >
-        </Transition>
         <span
             v-if="showHeaderText"
             ref="plate"
@@ -27,13 +15,11 @@
                 {{ headerText }}
             </h1>
         </span>
-        <SpeakerConfig v-if="speakerInHeader" />
     </header>
 </template>
 <script>
-import { mapGetters, mapState } from 'pinia';
+import { mapState } from 'pinia';
 import { usePostersStore } from '@/store/posters';
-import SpeakerConfig from '@/components/speaker-config.vue';
 import spreadsText from '@/mixins/spreads-text';
 
 export default {
@@ -41,18 +27,8 @@ export default {
         return {};
     },
     mixins: [spreadsText],
-    components: {
-        SpeakerConfig,
-    },
     computed: {
-        ...mapState(usePostersStore, [
-            'settings',
-            'nowPlaying',
-            'runtime',
-            'nowPlayingRuntime',
-            'currentPosterId',
-        ]),
-        ...mapGetters(usePostersStore, ['transitionPrefix']),
+        ...mapState(usePostersStore, ['settings', 'nowPlaying']),
         /**
          * The settings API hands booleans back as 0 and 1, so this cannot just
          * test against false - 0 !== false, and the header stayed on. Absent is
@@ -63,15 +39,6 @@ export default {
             const value = this.settings.show_header_text;
 
             return value === undefined || value === null ? true : !!Number(value);
-        },
-        transitionName() {
-            return this.transitionPrefix + '-meta';
-        },
-        speakerInHeader() {
-            return (
-                this.settings.speaker_config_location === 'top-right' &&
-                !!this.settings.show_speaker_config
-            );
         },
         plateStyleName() {
             const styles = ['plain', 'rules', 'marquee', 'plaque', 'neon'];
@@ -102,9 +69,6 @@ export default {
                 this.settings.header_font,
                 this.settings.header_font_size,
                 this.plateStyleName,
-                // These two decide how much room the line is left with.
-                this.settings.show_runtime,
-                this.speakerInHeader,
             ].join('|');
         },
         /**
@@ -120,9 +84,6 @@ export default {
             }
 
             return vars;
-        },
-        posterKey() {
-            return this.nowPlaying ? 'now-playing' : this.currentPosterId;
         },
         headerFont() {
             if (this.settings.header_font === 'default') {
@@ -173,10 +134,6 @@ export default {
                 return 'font-size: 9vh; padding: 6px 18px 8px 18px; ';
             }
         },
-        localRuntime() {
-            let rt = this.nowPlaying ? this.nowPlayingRuntime : this.runtime;
-            return rt ? rt.toFixed(0) : false;
-        },
         headerText() {
             return this.nowPlaying
                 ? this.settings.now_playing_text
@@ -206,79 +163,13 @@ export default {
 }
 
 /*
- * The runtime belongs to the poster, so it changes with it rather than
- * snapping to the next film while the artwork is still fading.
+ * A gutter, so a plate spanning the width has a little air at each end rather
+ * than running into the bezel. It matters most for a plaque, whose border would
+ * otherwise sit on the very edge of the screen and read as cut off.
  */
-/*
- * The details swap rather than overlap. The poster's cross-fade holds the
- * outgoing image at full opacity while the incoming one covers it, which works
- * because a poster covers a poster. These are centred text and icons of
- * different widths, so nothing covers anything and both sets were readable at
- * once. With out-in below, the old details leave before the new ones arrive,
- * and the whole swap still fits inside the poster's change.
- */
-.fade-meta-enter-active,
-.fade-meta-leave-active,
-.crossfade-meta-enter-active,
-.crossfade-meta-leave-active {
-    transition: opacity 0.6s ease;
-}
-
-.fade-meta-enter-from,
-.fade-meta-leave-to,
-.crossfade-meta-enter-from,
-.crossfade-meta-leave-to {
-    opacity: 0;
-}
-
-.slide-meta-enter-active,
-.slide-meta-leave-active {
-    transition:
-        transform 0.5s ease,
-        opacity 0.5s ease;
-}
-
-.slide-meta-leave-to {
-    transform: translate3d(0, -60%, 0);
-    opacity: 0;
-}
-
-.slide-meta-enter-from {
-    transform: translate3d(0, 60%, 0);
-    opacity: 0;
-}
-
-.cut-meta-enter-active,
-.cut-meta-leave-active {
-    transition: none;
-}
-
-/*
- * The runtime and the speaker badge float over the header rather than sitting
- * in the row with it, so a line of text spread to the full width runs straight
- * underneath them. These keep it clear of the space they take.
- *
- * A fixed reserve rather than a measurement of the badges: the runtime changes
- * with every poster, and reserving its exact width would shift the header text
- * a little on every change. The numbers are the offset each badge is positioned
- * at plus room for its longest sensible contents at its own type size.
- */
-.top-header.reserve-runtime {
-    padding-left: 16vw;
-}
-
-.top-header.reserve-speaker {
-    padding-right: 13vw;
-}
-
-.runtime {
-    position: absolute;
-    top: 50%;
-    left: 2%;
-    color: #fff;
-    font-size: 3vw;
-    font-weight: 400;
-    transform: translateY(-50%);
+.top-header--spread {
+    padding-left: 2vw;
+    padding-right: 2vw;
 }
 
 .rotated {
@@ -287,14 +178,6 @@ export default {
         h1 {
             font-size: 6vh;
         }
-    }
-    .runtime {
-        font-size: 1.4vw;
-        left: 5%;
-    }
-    // Smaller type here, so the reserve above is more than it needs.
-    .top-header.reserve-runtime {
-        padding-left: 11vw;
     }
 }
 </style>

--- a/tests/js/footer-details.test.js
+++ b/tests/js/footer-details.test.js
@@ -1,0 +1,113 @@
+import { mount } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { usePostersStore } from '@/store/posters';
+import BottomFooter from '@/components/bottom-footer.vue';
+import TopHeader from '@/components/top-header.vue';
+import ProcessingLogos from '@/components/processing-logos.vue';
+
+/**
+ * The top of the screen carries the header wording and the theatre name; the
+ * runtime and the speaker badge belong with the rest of what describes the
+ * poster, in the footer.
+ *
+ * Both used to float over the header, positioned rather than laid out in the
+ * row, which is what a header spread across the width kept running into.
+ */
+function footer(settings, state = {}) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    Object.assign(usePostersStore(), {
+        settings: { transition_type: 'fade', ...settings },
+        ...state,
+    });
+
+    return mount(BottomFooter, {
+        global: { plugins: [pinia], stubs: { StarRating: true } },
+    });
+}
+
+function header(settings, state = {}) {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    Object.assign(usePostersStore(), {
+        settings: { transition_type: 'fade', ...settings },
+        ...state,
+    });
+
+    return mount(TopHeader, { global: { plugins: [pinia] } });
+}
+
+describe('the runtime', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it('is drawn in the footer', () => {
+        const shown = footer({ show_runtime: true }, { runtime: 119 });
+
+        expect(shown.find('.runtime').text()).toBe('119 min');
+    });
+
+    it('is not drawn in the header any more', () => {
+        const shown = header({ show_runtime: true, show_header_text: true }, { runtime: 119 });
+
+        expect(shown.find('.runtime').exists()).toBe(false);
+    });
+
+    it('follows the now-playing film when one is on', () => {
+        const shown = footer(
+            { show_runtime: true },
+            { runtime: 119, nowPlayingRuntime: 92, nowPlaying: true },
+        );
+
+        expect(shown.find('.runtime').text()).toBe('92 min');
+    });
+
+    it('stays away when the setting is off', () => {
+        expect(footer({ show_runtime: false }, { runtime: 119 }).find('.runtime').exists()).toBe(
+            false,
+        );
+    });
+
+    /** Nothing to say before the first poster has been shown. */
+    it('stays away when there is no runtime to show', () => {
+        expect(footer({ show_runtime: true }, { runtime: 0 }).find('.runtime').exists()).toBe(
+            false,
+        );
+    });
+});
+
+describe('the speaker badge', () => {
+    beforeEach(() => setActivePinia(createPinia()));
+
+    it('is drawn in the footer', () => {
+        const shown = footer({ show_speaker_config: true, speaker_config: '7.1.4' });
+
+        expect(shown.find('.speaker-config-text').text()).toBe('7.1.4');
+    });
+
+    /**
+     * Regression: it was rendered inside the processing-logos component, whose
+     * root is behind the logos setting - so switching the logos off took the
+     * speaker badge with it, whatever the badge's own setting said.
+     */
+    it('survives the processing logos being switched off', () => {
+        const shown = footer({
+            show_speaker_config: true,
+            speaker_config: '7.1.4',
+            show_processing_logos: false,
+        });
+
+        expect(shown.findComponent(ProcessingLogos).find('.dolby-logos').exists()).toBe(false);
+        expect(shown.find('.speaker-config-text').text()).toBe('7.1.4');
+    });
+
+    it('is not drawn in the header any more', () => {
+        const shown = header({ show_speaker_config: true, speaker_config: '7.1.4' });
+
+        expect(shown.find('.speaker-config-text').exists()).toBe(false);
+    });
+
+    it('stays away when the setting is off', () => {
+        expect(footer({ show_speaker_config: false }).find('.speaker-config').exists()).toBe(false);
+    });
+});

--- a/tests/js/meta-transition.test.js
+++ b/tests/js/meta-transition.test.js
@@ -11,6 +11,9 @@ import { describe, expect, it } from 'vitest';
  * out-in is what makes them swap instead: the old details leave before the new
  * ones arrive.
  *
+ * The runtime used to have a Transition of its own in the header doing the same
+ * job. It sits in the footer row now and rides that one.
+ *
  * These are structural assertions rather than behavioural ones, and that is a
  * real limit. jsdom gives transitions no duration, so Vue settles them
  * immediately and a mounted component shows one set either way — the overlap
@@ -18,7 +21,6 @@ import { describe, expect, it } from 'vitest';
  * prevents it, and the timings that keep the swap inside the poster's change.
  */
 const components = {
-    'the runtime': 'resources/js/components/top-header.vue',
     'the footer details': 'resources/js/components/bottom-footer.vue',
 };
 
@@ -37,12 +39,14 @@ describe('the details around the poster', () => {
             // The poster's trick: hold, then drop once covered. Nothing covers
             // these, so holding leaves both readable at once.
             expect(source).not.toMatch(/crossfade-meta-leave-active[\s\S]{0,120}?linear\s+1\.6s/);
-        }
+        },
     );
 
     it.each(Object.entries(components))('%s finish inside the poster change', (_name, path) => {
         const source = readFileSync(path, 'utf8');
-        const durations = [...source.matchAll(/-meta-(?:enter|leave)-active[\s\S]{0,160}?([\d.]+)s/g)]
+        const durations = [
+            ...source.matchAll(/-meta-(?:enter|leave)-active[\s\S]{0,160}?([\d.]+)s/g),
+        ]
             .map((m) => Number(m[1]))
             .filter((n) => n > 0);
 

--- a/tests/js/scrim-sides.test.js
+++ b/tests/js/scrim-sides.test.js
@@ -54,10 +54,6 @@ describe('shading only where there is something to shade', () => {
         expect(sides(dashboard({ show_header_text: true }))).toEqual({ top: true, bottom: false });
     });
 
-    it('shades the top for the runtime alone', () => {
-        expect(sides(dashboard({ show_runtime: true }))).toEqual({ top: true, bottom: false });
-    });
-
     it.each([
         ['the content rating', 'show_mpaa_rating'],
         ['the processing logos', 'show_processing_logos'],
@@ -80,13 +76,14 @@ describe('shading only where there is something to shade', () => {
             .toEqual({ top: false, bottom: true });
     });
 
-    it('follows the speaker config to its own corner', () => {
-        const on = { show_speaker_config: true };
-
-        expect(sides(dashboard({ ...on, speaker_config_location: 'top-right' })))
-            .toEqual({ top: true, bottom: false });
-        expect(sides(dashboard({ ...on, speaker_config_location: 'bottom' })))
-            .toEqual({ top: false, bottom: true });
+    it('shades the footer for the speaker config and the runtime', () => {
+        // Both moved down from the header, so neither asks for shading at the
+        // top any more.
+        expect(sides(dashboard({ show_speaker_config: true }))).toEqual({
+            top: false,
+            bottom: true,
+        });
+        expect(sides(dashboard({ show_runtime: true }))).toEqual({ top: false, bottom: true });
     });
 
     it('suppresses each end independently', () => {

--- a/tests/js/settings-layout.test.js
+++ b/tests/js/settings-layout.test.js
@@ -96,7 +96,6 @@ describe('every setting has exactly one home', () => {
             'show_audience_rating',
             'show_speaker_config',
             'speaker_config',
-            'speaker_config_location',
             'show_processing_logos',
             'show_dolby_51',
             'show_dolby_atmos_vertical',

--- a/tests/js/spread-text.test.js
+++ b/tests/js/spread-text.test.js
@@ -142,56 +142,42 @@ describe('which theatre name plates spread', () => {
     });
 });
 
-describe('the header keeping clear of the badges over it', () => {
+describe('a header spread across the width', () => {
     beforeEach(() => setActivePinia(createPinia()));
 
     /**
-     * Regression: the runtime and the speaker badge are positioned over the
-     * header rather than laid out in the row with it, so a line spread to the
-     * full width ran straight underneath both of them.
+     * The runtime and the speaker badge used to float over the header, and a
+     * line spread to the full width ran straight underneath both. They live in
+     * the footer now, so the header has the width to itself - but a plaque
+     * still needs a gutter, or its border sits on the very edge of the screen.
      */
-    it('reserves the runtime end when a spread header shows one', () => {
+    it('takes a gutter so a bordered plate is not flush with the screen edge', () => {
         const header = plate(TopHeader, {
             show_header_text: true,
             header_full_width: true,
-            show_runtime: true,
+            header_style: 'plaque',
         });
 
-        expect(header.classes()).toContain('reserve-runtime');
+        expect(header.classes()).toContain('top-header--spread');
     });
 
-    it('reserves the speaker end when a spread header shows the badge', () => {
-        const header = plate(TopHeader, {
-            show_header_text: true,
-            header_full_width: true,
-            show_speaker_config: true,
-            speaker_config_location: 'top-right',
-        });
-
-        expect(header.classes()).toContain('reserve-speaker');
-    });
-
-    it('does not reserve the speaker end when the badge sits under the poster', () => {
-        const header = plate(TopHeader, {
-            show_header_text: true,
-            header_full_width: true,
-            show_speaker_config: true,
-            speaker_config_location: 'bottom',
-        });
-
-        expect(header.classes()).not.toContain('reserve-speaker');
-    });
-
-    it('reserves nothing on a header that hugs its words', () => {
+    it('takes no gutter when the plate hugs its words', () => {
         const header = plate(TopHeader, {
             show_header_text: true,
             header_full_width: false,
-            show_runtime: true,
-            show_speaker_config: true,
-            speaker_config_location: 'top-right',
         });
 
-        expect(header.classes()).not.toContain('reserve-runtime');
-        expect(header.classes()).not.toContain('reserve-speaker');
+        expect(header.classes()).not.toContain('top-header--spread');
+    });
+
+    it('no longer carries the runtime or the speaker badge', () => {
+        const header = plate(TopHeader, {
+            show_header_text: true,
+            show_runtime: true,
+            show_speaker_config: true,
+        });
+
+        expect(header.find('.runtime').exists()).toBe(false);
+        expect(header.findComponent({ name: 'SpeakerConfig' }).exists()).toBe(false);
     });
 });


### PR DESCRIPTION
## What you reported

Span the width with a **plaque** produced a band shoved off centre, with its right border sitting on the very edge of the screen.

Measured on the running display with your settings: the header was padded **204.8px on the left and 0 on the right**. The plate itself was sized correctly — it just started 204.8px in and ended exactly on the screen edge.

That padding was the runtime reserve from #54. It kept spread *words* clear of the runtime badge, which worked when both badges were shown and looked broken when only one was.

## What changed

You asked for the runtime and the speaker layout to move to the bottom, leaving the top to the header and the theatre name. That removes the cause rather than balancing it:

- The runtime sits in the footer beside the content rating, and rides the footer row's existing swap instead of carrying a `<Transition>` of its own to do the same job.
- The speaker badge is footer-only. `speaker_config_location` is dropped — a display set to *top right* keeps the badge, in the footer.
- The reserve machinery is gone. The header has the width to itself, less a **2vw gutter** so a plaque's border does not run into the bezel.

Verified after: header padding **25.6px on both sides**, plate from 25.6 to 1254.4 on a 1280 screen. Even at both ends.

## A bug found while moving it

The speaker badge was rendered *inside* `processing-logos.vue`, whose root is `v-if="settings.show_processing_logos"`. **Switching processing logos off hid the speaker badge too**, whatever its own setting said. It is a sibling in the footer row now, with a test.

## Verification, and one honest limit

The plaque geometry and the empty header were measured in the browser and confirmed by screenshot.

I could **not** get a reliable visual confirmation of the footer. This browser pane does not complete CSS transitions, so the footer's `mode="out-in"` row gets stuck mid-leave at `opacity: 0` and the DOM keeps a stale outgoing row — I watched it hold classes `crossfade-meta-enter-from crossfade-meta-leave-from crossfade-meta-leave-active` indefinitely. Clearing them by hand showed the runtime rendering correctly beside the rating, but that is a frame I forced rather than one the app produced.

So the footer is pinned in jsdom instead, where it is deterministic: 9 tests covering the runtime in the footer and gone from the header, now-playing runtime, both off-switches, and the speaker badge surviving the logos being switched off.

141 front-end tests, 196 PHP, Pint clean. Local database backed up before the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)